### PR TITLE
feat: v0.15.0 — Plugin Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,100 @@ LuckyHarness 是一个用 Go 重写的 AI Agent 框架，参考 Hermes Agent 的
 | v0.12.0 | API Server | HTTP RESTful API + SSE 流式 + 认证限流 |
 | v0.13.0 | Context Window | Token 估算 + 4 种裁剪策略 + 优先级管理 |
 | v0.14.0 | RAG 知识库 | 向量索引 + 语义检索 + 持久化 + API 端点 |
+| v0.15.0 | Plugin Marketplace | 插件清单 + 注册中心 + 安装器 + 沙箱 + CLI/API |
+
+## v0.15.0 新特性
+
+### Plugin Marketplace
+
+内置插件市场系统，支持插件的安装、卸载、更新、搜索和权限管理：
+
+```bash
+# 安装插件（本地路径）
+lh plugin install /path/to/my-plugin
+
+# 列出已安装插件
+lh plugin list
+
+# 查看插件详情
+lh plugin info my-plugin
+
+# 搜索插件
+lh plugin search "web search"
+
+# 更新插件
+lh plugin update my-plugin /path/to/new-version
+
+# 启用/禁用插件
+lh plugin enable my-plugin
+lh plugin disable my-plugin
+
+# 卸载插件
+lh plugin remove my-plugin
+```
+
+### plugin.yaml 清单格式
+
+```yaml
+name: my-plugin
+version: 1.0.0
+author: author-name
+description: A cool plugin
+license: MIT
+homepage: https://example.com
+entry: main.go
+type: skill          # skill | tool | provider | hook
+min_version: 0.14.0
+tags:
+  - search
+  - web
+dependencies:
+  - base-plugin@1.0.0
+permissions:
+  - filesystem
+  - network
+```
+
+### 权限系统
+
+8 种权限级别，默认受限模式：
+
+| 权限 | 说明 |
+|------|------|
+| filesystem | 文件系统访问 |
+| network | 网络访问 |
+| memory | 记忆系统访问 |
+| tool | 工具注册 |
+| rag | RAG 知识库访问 |
+| session | 会话访问 |
+| config | 配置修改 |
+| admin | 管理员操作 |
+
+### API 端点
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/api/v1/plugins` | 插件列表（支持 ?type=&status= 过滤） |
+| GET | `/api/v1/plugins/search?q=` | 搜索插件 |
+| POST | `/api/v1/plugins/install` | 安装插件 |
+| DELETE | `/api/v1/plugins/{name}` | 卸载插件 |
+| POST | `/api/v1/plugins/{name}/enable` | 启用插件 |
+| POST | `/api/v1/plugins/{name}/disable` | 禁用插件 |
+| GET | `/api/v1/plugins/{name}/permissions` | 查看权限 |
+| POST | `/api/v1/plugins/{name}/permissions` | 授予/撤销权限 |
+
+### 资源限制
+
+默认沙箱限制：
+
+| 限制项 | 默认值 |
+|--------|--------|
+| 最大内存 | 256 MB |
+| 最大 CPU | 50% |
+| 最大 Goroutine | 10 |
+| 执行超时 | 30s |
+| 最大输出 | 1 MB |
+| 调用频率 | 60/min |
 
 ## v0.14.0 新特性
 

--- a/cmd/lh/main.go
+++ b/cmd/lh/main.go
@@ -94,7 +94,7 @@ func main() {
 		Use:   "version",
 		Short: "显示版本",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("🍀 LuckyHarness v0.14.0")
+			fmt.Println("🍀 LuckyHarness v0.15.0")
 		},
 	}
 
@@ -370,9 +370,65 @@ func main() {
 	}
 	ragCmd.AddCommand(ragIndexCmd, ragSearchCmd, ragStatsCmd)
 
+	// ===== v0.15.0: Plugin 命令 =====
+	pluginCmd := &cobra.Command{
+		Use:   "plugin",
+		Short: "插件管理",
+	}
+	pluginInstallCmd := &cobra.Command{
+		Use:   "install <path>",
+		Short: "安装插件（本地路径）",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runPluginInstall,
+	}
+	pluginListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "列出已安装插件",
+		RunE:  runPluginList,
+	}
+	pluginRemoveCmd := &cobra.Command{
+		Use:   "remove <name>",
+		Short: "卸载插件",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runPluginRemove,
+	}
+	pluginUpdateCmd := &cobra.Command{
+		Use:   "update <name> <path>",
+		Short: "更新插件",
+		Args:  cobra.ExactArgs(2),
+		RunE:  runPluginUpdate,
+	}
+	pluginSearchCmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "搜索插件",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runPluginSearch,
+	}
+	pluginInfoCmd := &cobra.Command{
+		Use:   "info <name>",
+		Short: "查看插件详情",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runPluginInfo,
+	}
+	pluginEnableCmd := &cobra.Command{
+		Use:   "enable <name>",
+		Short: "启用插件",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runPluginEnable,
+	}
+	pluginDisableCmd := &cobra.Command{
+		Use:   "disable <name>",
+		Short: "禁用插件",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runPluginDisable,
+	}
+	pluginCmd.AddCommand(pluginInstallCmd, pluginListCmd, pluginRemoveCmd,
+		pluginUpdateCmd, pluginSearchCmd, pluginInfoCmd,
+		pluginEnableCmd, pluginDisableCmd)
+
 	rootCmd.AddCommand(initCmd, chatCmd, configCmd, soulCmd, modelsCmd, versionCmd,
 		profileCmd, backupCmd, dashboardCmd, debugCmd,
-		gatewayCmd, subCmd, usageCmd, serveCmd, ragCmd)
+		gatewayCmd, subCmd, usageCmd, serveCmd, ragCmd, pluginCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/internal/plugin/installer.go
+++ b/internal/plugin/installer.go
@@ -1,0 +1,207 @@
+package plugin
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Installer 插件安装器
+type Installer struct {
+	registry    *Registry
+	pluginsDir  string
+	httpClient  *http.Client
+}
+
+// NewInstaller 创建插件安装器
+func NewInstaller(registry *Registry, pluginsDir string) *Installer {
+	return &Installer{
+		registry:   registry,
+		pluginsDir: pluginsDir,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// InstallResult 安装结果
+type InstallResult struct {
+	Name       string
+	Version    string
+	InstallDir string
+	Installed  bool
+	Updated    bool // true if this was an update
+	Error      string
+}
+
+// Install 从本地目录安装插件
+func (inst *Installer) Install(localPath string) (*InstallResult, error) {
+	// 读取 plugin.yaml
+	manifestPath := filepath.Join(localPath, "plugin.yaml")
+	manifest, err := LoadManifest(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("load manifest: %w", err)
+	}
+
+	if err := manifest.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid manifest: %w", err)
+	}
+
+	// 检查是否已安装
+	_, alreadyInstalled := inst.registry.Get(manifest.Name)
+	isUpdate := alreadyInstalled
+
+	// 创建目标目录
+	targetDir := filepath.Join(inst.pluginsDir, manifest.Name)
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		return nil, fmt.Errorf("create plugin dir: %w", err)
+	}
+
+	// 复制文件
+	if err := copyDir(localPath, targetDir); err != nil {
+		return nil, fmt.Errorf("copy plugin files: %w", err)
+	}
+
+	// 更新清单中的安装路径
+	manifest.InstallPath = targetDir
+	manifest.InstalledAt = time.Now()
+
+	// 注册到 Registry
+	inst.registry.Register(manifest)
+
+	return &InstallResult{
+		Name:       manifest.Name,
+		Version:    manifest.Version,
+		InstallDir: targetDir,
+		Installed:  true,
+		Updated:    isUpdate,
+	}, nil
+}
+
+// InstallFromURL 从 URL 下载并安装插件
+func (inst *Installer) InstallFromURL(downloadURL string) (*InstallResult, error) {
+	// 下载到临时目录
+	tmpDir, err := os.MkdirTemp("", "lh-plugin-*")
+	if err != nil {
+		return nil, fmt.Errorf("create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// 下载
+	resp, err := inst.httpClient.Get(downloadURL)
+	if err != nil {
+		return nil, fmt.Errorf("download plugin: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("download failed: HTTP %d", resp.StatusCode)
+	}
+
+	// 保存到临时文件
+	tmpFile := filepath.Join(tmpDir, "plugin.zip")
+	f, err := os.Create(tmpFile)
+	if err != nil {
+		return nil, fmt.Errorf("create temp file: %w", err)
+	}
+
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("save download: %w", err)
+	}
+	f.Close()
+
+	// TODO: 解压 zip 并安装
+	// 当前版本只支持本地目录安装
+	return nil, fmt.Errorf("URL installation not yet implemented (use local path)")
+}
+
+// Uninstall 卸载插件
+func (inst *Installer) Uninstall(name string) error {
+	entry, ok := inst.registry.Get(name)
+	if !ok {
+		return fmt.Errorf("plugin not found: %s", name)
+	}
+
+	// 删除插件目录
+	if entry.Manifest.InstallPath != "" {
+		if err := os.RemoveAll(entry.Manifest.InstallPath); err != nil {
+			return fmt.Errorf("remove plugin dir: %w", err)
+		}
+	}
+
+	// 从注册表移除
+	return inst.registry.Unregister(name)
+}
+
+// Update 更新插件（重新安装）
+func (inst *Installer) Update(name string, localPath string) (*InstallResult, error) {
+	_, ok := inst.registry.Get(name)
+	if !ok {
+		return nil, fmt.Errorf("plugin not found: %s", name)
+	}
+
+	// 先卸载旧版本
+	if err := inst.Uninstall(name); err != nil {
+		return nil, fmt.Errorf("uninstall old version: %w", err)
+	}
+
+	// 安装新版本
+	result, err := inst.Install(localPath)
+	if err != nil {
+		return nil, fmt.Errorf("install new version: %w", err)
+	}
+
+	result.Updated = true
+	return result, nil
+}
+
+// GetInstalledPath 获取已安装插件的路径
+func (inst *Installer) GetInstalledPath(name string) (string, error) {
+	entry, ok := inst.registry.Get(name)
+	if !ok {
+		return "", fmt.Errorf("plugin not found: %s", name)
+	}
+	if entry.Manifest.InstallPath == "" {
+		return "", fmt.Errorf("plugin install path not set: %s", name)
+	}
+	return entry.Manifest.InstallPath, nil
+}
+
+// copyDir 递归复制目录
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, _ := filepath.Rel(src, path)
+		targetPath := filepath.Join(dst, relPath)
+
+		if info.IsDir() {
+			// 跳过 .git 目录
+			if strings.Contains(relPath, ".git") {
+				return nil
+			}
+			return os.MkdirAll(targetPath, 0755)
+		}
+
+		// 跳过 .git 文件
+		if strings.Contains(relPath, ".git") {
+			return nil
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		// 保留可执行权限
+		perm := info.Mode().Perm()
+		return os.WriteFile(targetPath, data, perm)
+	})
+}

--- a/internal/plugin/installer_test.go
+++ b/internal/plugin/installer_test.go
@@ -1,0 +1,223 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallerInstall(t *testing.T) {
+	// 创建源插件目录
+	srcDir := t.TempDir()
+	srcPluginDir := filepath.Join(srcDir, "my-plugin")
+	os.MkdirAll(srcPluginDir, 0755)
+
+	manifestContent := `name: my-plugin
+version: 1.0.0
+author: test-author
+description: A test plugin
+entry: main.go
+type: skill
+`
+	os.WriteFile(filepath.Join(srcPluginDir, "plugin.yaml"), []byte(manifestContent), 0644)
+	os.WriteFile(filepath.Join(srcPluginDir, "main.go"), []byte("package main"), 0644)
+
+	// 创建目标目录
+	dstDir := t.TempDir()
+
+	reg := NewRegistry(dstDir)
+	inst := NewInstaller(reg, dstDir)
+
+	result, err := inst.Install(srcPluginDir)
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+
+	if result.Name != "my-plugin" {
+		t.Errorf("Name = %v, want my-plugin", result.Name)
+	}
+	if result.Version != "1.0.0" {
+		t.Errorf("Version = %v, want 1.0.0", result.Version)
+	}
+	if !result.Installed {
+		t.Error("Installed = false, want true")
+	}
+	if result.Updated {
+		t.Error("Updated = true, want false (first install)")
+	}
+
+	// 验证注册表
+	if reg.Count() != 1 {
+		t.Errorf("Count() = %d, want 1", reg.Count())
+	}
+
+	// 验证文件复制
+	if _, err := os.Stat(filepath.Join(dstDir, "my-plugin", "plugin.yaml")); os.IsNotExist(err) {
+		t.Error("plugin.yaml not copied")
+	}
+	if _, err := os.Stat(filepath.Join(dstDir, "my-plugin", "main.go")); os.IsNotExist(err) {
+		t.Error("main.go not copied")
+	}
+}
+
+func TestInstallerUninstall(t *testing.T) {
+	srcDir := t.TempDir()
+	srcPluginDir := filepath.Join(srcDir, "my-plugin")
+	os.MkdirAll(srcPluginDir, 0755)
+
+	manifestContent := `name: my-plugin
+version: 1.0.0
+author: test-author
+description: A test plugin
+entry: main.go
+type: skill
+`
+	os.WriteFile(filepath.Join(srcPluginDir, "plugin.yaml"), []byte(manifestContent), 0644)
+
+	dstDir := t.TempDir()
+	reg := NewRegistry(dstDir)
+	inst := NewInstaller(reg, dstDir)
+
+	// 先安装
+	inst.Install(srcPluginDir)
+
+	// 再卸载
+	if err := inst.Uninstall("my-plugin"); err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+
+	if reg.Count() != 0 {
+		t.Errorf("Count() = %d, want 0", reg.Count())
+	}
+
+	// 验证目录已删除
+	if _, err := os.Stat(filepath.Join(dstDir, "my-plugin")); !os.IsNotExist(err) {
+		t.Error("plugin directory should be deleted")
+	}
+}
+
+func TestInstallerUninstallNonexistent(t *testing.T) {
+	dstDir := t.TempDir()
+	reg := NewRegistry(dstDir)
+	inst := NewInstaller(reg, dstDir)
+
+	if err := inst.Uninstall("nonexistent"); err == nil {
+		t.Error("Uninstall(nonexistent) should return error")
+	}
+}
+
+func TestInstallerUpdate(t *testing.T) {
+	srcDir := t.TempDir()
+
+	// 创建 v1.0.0
+	v1Dir := filepath.Join(srcDir, "my-plugin-v1")
+	os.MkdirAll(v1Dir, 0755)
+	v1Manifest := `name: my-plugin
+version: 1.0.0
+author: test-author
+description: Version 1
+entry: main.go
+type: skill
+`
+	os.WriteFile(filepath.Join(v1Dir, "plugin.yaml"), []byte(v1Manifest), 0644)
+
+	// 创建 v2.0.0
+	v2Dir := filepath.Join(srcDir, "my-plugin-v2")
+	os.MkdirAll(v2Dir, 0755)
+	v2Manifest := `name: my-plugin
+version: 2.0.0
+author: test-author
+description: Version 2
+entry: main.go
+type: skill
+`
+	os.WriteFile(filepath.Join(v2Dir, "plugin.yaml"), []byte(v2Manifest), 0644)
+
+	dstDir := t.TempDir()
+	reg := NewRegistry(dstDir)
+	inst := NewInstaller(reg, dstDir)
+
+	// 安装 v1
+	result, err := inst.Install(v1Dir)
+	if err != nil {
+		t.Fatalf("Install v1 error = %v", err)
+	}
+	if result.Version != "1.0.0" {
+		t.Errorf("Version = %v, want 1.0.0", result.Version)
+	}
+
+	// 更新到 v2
+	result, err = inst.Update("my-plugin", v2Dir)
+	if err != nil {
+		t.Fatalf("Update error = %v", err)
+	}
+	if result.Version != "2.0.0" {
+		t.Errorf("Version = %v, want 2.0.0", result.Version)
+	}
+	if !result.Updated {
+		t.Error("Updated = false, want true")
+	}
+
+	// 验证注册表中的版本
+	entry, ok := reg.Get("my-plugin")
+	if !ok {
+		t.Error("Get(my-plugin) not found after update")
+	}
+	if entry.Manifest.Version != "2.0.0" {
+		t.Errorf("Version after update = %v, want 2.0.0", entry.Manifest.Version)
+	}
+}
+
+func TestInstallerInstallInvalidManifest(t *testing.T) {
+	srcDir := t.TempDir()
+	srcPluginDir := filepath.Join(srcDir, "bad-plugin")
+	os.MkdirAll(srcPluginDir, 0755)
+
+	// 缺少必要字段的 manifest
+	badManifest := `description: Missing name and version
+`
+	os.WriteFile(filepath.Join(srcPluginDir, "plugin.yaml"), []byte(badManifest), 0644)
+
+	dstDir := t.TempDir()
+	reg := NewRegistry(dstDir)
+	inst := NewInstaller(reg, dstDir)
+
+	_, err := inst.Install(srcPluginDir)
+	if err == nil {
+		t.Error("Install() should fail for invalid manifest")
+	}
+}
+
+func TestInstallerGetInstalledPath(t *testing.T) {
+	srcDir := t.TempDir()
+	srcPluginDir := filepath.Join(srcDir, "my-plugin")
+	os.MkdirAll(srcPluginDir, 0755)
+
+	manifestContent := `name: my-plugin
+version: 1.0.0
+author: test-author
+description: A test plugin
+entry: main.go
+type: skill
+`
+	os.WriteFile(filepath.Join(srcPluginDir, "plugin.yaml"), []byte(manifestContent), 0644)
+
+	dstDir := t.TempDir()
+	reg := NewRegistry(dstDir)
+	inst := NewInstaller(reg, dstDir)
+
+	inst.Install(srcPluginDir)
+
+	path, err := inst.GetInstalledPath("my-plugin")
+	if err != nil {
+		t.Fatalf("GetInstalledPath() error = %v", err)
+	}
+	if path == "" {
+		t.Error("GetInstalledPath() returned empty path")
+	}
+
+	_, err = inst.GetInstalledPath("nonexistent")
+	if err == nil {
+		t.Error("GetInstalledPath(nonexistent) should return error")
+	}
+}

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -1,0 +1,167 @@
+package plugin
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// PluginStatus 插件状态
+type PluginStatus string
+
+const (
+	StatusInstalled  PluginStatus = "installed"
+	StatusAvailable  PluginStatus = "available"
+	StatusUpdate     PluginStatus = "update_available"
+	StatusDisabled   PluginStatus = "disabled"
+	StatusError      PluginStatus = "error"
+)
+
+// Permission 插件权限
+type Permission string
+
+const (
+	PermFileSystem Permission = "filesystem" // 文件系统访问
+	PermNetwork    Permission = "network"    // 网络访问
+	PermMemory     Permission = "memory"     // 记忆系统访问
+	PermTool       Permission = "tool"       // 工具注册
+	PermRAG        Permission = "rag"        // RAG 知识库访问
+	PermSession    Permission = "session"    // 会话访问
+	PermConfig     Permission = "config"     // 配置修改
+	PermAdmin      Permission = "admin"      // 管理员操作
+)
+
+// Manifest 插件清单（plugin.yaml 格式）
+type Manifest struct {
+	// 基本信息
+	Name        string   `yaml:"name" json:"name"`
+	Version     string   `yaml:"version" json:"version"`
+	Author      string   `yaml:"author" json:"author"`
+	Description string   `yaml:"description" json:"description"`
+	License     string   `yaml:"license,omitempty" json:"license,omitempty"`
+	Homepage    string   `yaml:"homepage,omitempty" json:"homepage,omitempty"`
+	Repository  string   `yaml:"repository,omitempty" json:"repository,omitempty"`
+
+	// 入口
+	Entry    string   `yaml:"entry" json:"entry"`       // 入口文件（相对于插件目录）
+	Type     string   `yaml:"type" json:"type"`         // 插件类型: skill, tool, provider, hook
+	Tags     []string `yaml:"tags,omitempty" json:"tags,omitempty"`
+
+	// 依赖
+	Dependencies []Dependency `yaml:"dependencies,omitempty" json:"dependencies,omitempty"`
+	MinVersion   string       `yaml:"min_version,omitempty" json:"min_version,omitempty"` // 最低 LuckyHarness 版本
+
+	// 权限
+	Permissions []Permission `yaml:"permissions,omitempty" json:"permissions,omitempty"`
+
+	// 配置
+	ConfigSchema map[string]ConfigField `yaml:"config_schema,omitempty" json:"config_schema,omitempty"`
+
+	// 运行时（安装后填充）
+	InstallPath string    `yaml:"-" json:"install_path,omitempty"`
+	InstalledAt time.Time `yaml:"-" json:"installed_at,omitempty"`
+	Checksum    string    `yaml:"-" json:"checksum,omitempty"` // 安装包校验和
+}
+
+// Dependency 插件依赖
+type Dependency struct {
+	Name    string `yaml:"name" json:"name"`
+	Version string `yaml:"version,omitempty" json:"version,omitempty"` // semver range
+}
+
+// ConfigField 插件配置字段定义
+type ConfigField struct {
+	Type        string `yaml:"type" json:"type"`                 // string, int, bool, float
+	Default     any    `yaml:"default,omitempty" json:"default,omitempty"`
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+	Required    bool   `yaml:"required,omitempty" json:"required,omitempty"`
+}
+
+// Validate 验证 Manifest 完整性
+func (m *Manifest) Validate() error {
+	if m.Name == "" {
+		return fmt.Errorf("plugin name is required")
+	}
+	if m.Version == "" {
+		return fmt.Errorf("plugin version is required")
+	}
+	if m.Entry == "" {
+		return fmt.Errorf("plugin entry is required")
+	}
+	if m.Type == "" {
+		return fmt.Errorf("plugin type is required")
+	}
+
+	// 验证类型
+	validTypes := map[string]bool{
+		"skill":    true,
+		"tool":     true,
+		"provider": true,
+		"hook":     true,
+	}
+	if !validTypes[m.Type] {
+		return fmt.Errorf("invalid plugin type: %s (must be skill, tool, provider, or hook)", m.Type)
+	}
+
+	// 验证名称格式（小写字母、数字、连字符）
+	for _, ch := range m.Name {
+		if !((ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '-') {
+			return fmt.Errorf("invalid plugin name: %s (lowercase letters, digits, hyphens only)", m.Name)
+		}
+	}
+
+	// 验证版本格式（semver）
+	if !isValidVersion(m.Version) {
+		return fmt.Errorf("invalid version format: %s (expected semver)", m.Version)
+	}
+
+	return nil
+}
+
+// FullName 返回插件的完整标识（name@version）
+func (m *Manifest) FullName() string {
+	return fmt.Sprintf("%s@%s", m.Name, m.Version)
+}
+
+// HasPermission 检查插件是否有指定权限
+func (m *Manifest) HasPermission(perm Permission) bool {
+	for _, p := range m.Permissions {
+		if p == perm {
+			return true
+		}
+	}
+	return false
+}
+
+// HasDependency 检查插件是否依赖指定插件
+func (m *Manifest) HasDependency(name string) bool {
+	for _, d := range m.Dependencies {
+		if d.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// isValidVersion 检查版本号是否为有效 semver
+func isValidVersion(v string) bool {
+	if v == "" {
+		return false
+	}
+	parts := strings.Split(v, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	for _, p := range parts {
+		for _, ch := range p {
+			if ch < '0' || ch > '9' {
+				// 允许预发布后缀如 1.0.0-alpha
+				if ch == '-' && len(p) > 0 {
+					return true
+				}
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/internal/plugin/manifest_io.go
+++ b/internal/plugin/manifest_io.go
@@ -1,0 +1,281 @@
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// LoadManifest 从文件加载插件清单
+func LoadManifest(path string) (*Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read manifest: %w", err)
+	}
+
+	// 简单 YAML 解析（避免引入 yaml 依赖）
+	return parseManifest(string(data))
+}
+
+// SaveManifest 保存插件清单到文件
+func SaveManifest(manifest *Manifest, path string) error {
+	if err := manifest.Validate(); err != nil {
+		return fmt.Errorf("invalid manifest: %w", err)
+	}
+
+	content := formatManifest(manifest)
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("create dir: %w", err)
+	}
+
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		return fmt.Errorf("write manifest: %w", err)
+	}
+
+	return nil
+}
+
+// parseManifest 简单 YAML 解析器
+func parseManifest(content string) (*Manifest, error) {
+	m := &Manifest{
+	Permissions:  []Permission{},
+	Dependencies: []Dependency{},
+		Tags:         []string{},
+		ConfigSchema: map[string]ConfigField{},
+	}
+
+	lines := splitLines(content)
+	var currentSection string
+
+	for _, line := range lines {
+		trimmed := trimSpace(line)
+
+		// 跳过空行和注释
+		if trimmed == "" || hasPrefix(trimmed, "#") {
+			continue
+		}
+
+		// Section headers
+		if hasPrefix(trimmed, "dependencies:") {
+			currentSection = "dependencies"
+			continue
+		}
+		if hasPrefix(trimmed, "permissions:") {
+			currentSection = "permissions"
+			continue
+		}
+		if hasPrefix(trimmed, "tags:") {
+			currentSection = "tags"
+			continue
+		}
+
+		// List items
+		if hasPrefix(trimmed, "- ") {
+			item := trimPrefix(trimmed, "- ")
+			switch currentSection {
+			case "dependencies":
+				dep := parseDependency(item)
+				m.Dependencies = append(m.Dependencies, dep)
+			case "permissions":
+				m.Permissions = append(m.Permissions, Permission(trimSpace(item)))
+			case "tags":
+				m.Tags = append(m.Tags, trimSpace(item))
+			}
+			continue
+		}
+
+		// Key-value pairs
+		key, value, ok := parseKV(trimmed)
+		if !ok {
+			continue
+		}
+
+		currentSection = "" // reset section on key-value
+
+		switch key {
+		case "name":
+			m.Name = value
+		case "version":
+			m.Version = value
+		case "author":
+			m.Author = value
+		case "description":
+			m.Description = value
+		case "license":
+			m.License = value
+		case "homepage":
+			m.Homepage = value
+		case "repository":
+			m.Repository = value
+		case "entry":
+			m.Entry = value
+		case "type":
+			m.Type = value
+		case "min_version":
+			m.MinVersion = value
+		}
+	}
+
+	return m, nil
+}
+
+// parseDependency 解析依赖条目 "name@version" 或 "name"
+func parseDependency(s string) Dependency {
+	parts := splitString(s, "@")
+	dep := Dependency{Name: trimSpace(parts[0])}
+	if len(parts) > 1 {
+		dep.Version = trimSpace(parts[1])
+	}
+	return dep
+}
+
+// parseKV 解析 "key: value" 格式
+func parseKV(s string) (string, string, bool) {
+	idx := indexOfColon(s)
+	if idx < 0 {
+		return "", "", false
+	}
+	key := trimSpace(s[:idx])
+	value := trimSpace(s[idx+1:])
+	// 去除引号
+	if len(value) >= 2 && ((value[0] == '"' && value[len(value)-1] == '"') ||
+		(value[0] == '\'' && value[len(value)-1] == '\'')) {
+		value = value[1 : len(value)-1]
+	}
+	return key, value, true
+}
+
+// formatManifest 格式化清单为 YAML
+func formatManifest(m *Manifest) string {
+	var s string
+	s += fmt.Sprintf("name: %s\n", m.Name)
+	s += fmt.Sprintf("version: %s\n", m.Version)
+	s += fmt.Sprintf("author: %s\n", m.Author)
+	s += fmt.Sprintf("description: %s\n", m.Description)
+	if m.License != "" {
+		s += fmt.Sprintf("license: %s\n", m.License)
+	}
+	if m.Homepage != "" {
+		s += fmt.Sprintf("homepage: %s\n", m.Homepage)
+	}
+	if m.Repository != "" {
+		s += fmt.Sprintf("repository: %s\n", m.Repository)
+	}
+	s += fmt.Sprintf("entry: %s\n", m.Entry)
+	s += fmt.Sprintf("type: %s\n", m.Type)
+	if m.MinVersion != "" {
+		s += fmt.Sprintf("min_version: %s\n", m.MinVersion)
+	}
+
+	if len(m.Tags) > 0 {
+		s += "tags:\n"
+		for _, tag := range m.Tags {
+			s += fmt.Sprintf("  - %s\n", tag)
+		}
+	}
+
+	if len(m.Dependencies) > 0 {
+		s += "dependencies:\n"
+		for _, dep := range m.Dependencies {
+			if dep.Version != "" {
+				s += fmt.Sprintf("  - %s@%s\n", dep.Name, dep.Version)
+			} else {
+				s += fmt.Sprintf("  - %s\n", dep.Name)
+			}
+		}
+	}
+
+	if len(m.Permissions) > 0 {
+		s += "permissions:\n"
+		for _, perm := range m.Permissions {
+			s += fmt.Sprintf("  - %s\n", perm)
+		}
+	}
+
+	return s
+}
+
+// --- string helpers (avoid importing strings for simple ops) ---
+
+func splitLines(s string) []string {
+	var lines []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			lines = append(lines, s[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		lines = append(lines, s[start:])
+	}
+	return lines
+}
+
+func trimSpace(s string) string {
+	start, end := 0, len(s)
+	for start < end && (s[start] == ' ' || s[start] == '\t') {
+		start++
+	}
+	for end > start && (s[end-1] == ' ' || s[end-1] == '\t') {
+		end--
+	}
+	return s[start:end]
+}
+
+func hasPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}
+
+func trimPrefix(s, prefix string) string {
+	if hasPrefix(s, prefix) {
+		return s[len(prefix):]
+	}
+	return s
+}
+
+func indexOfColon(s string) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == ':' {
+			return i
+		}
+	}
+	return -1
+}
+
+func splitString(s, sep string) []string {
+	if len(sep) == 0 {
+		return []string{s}
+	}
+	var parts []string
+	for {
+		idx := findString(s, sep)
+		if idx < 0 {
+			parts = append(parts, s)
+			break
+		}
+		parts = append(parts, s[:idx])
+		s = s[idx+len(sep):]
+	}
+	return parts
+}
+
+func findString(s, substr string) int {
+	if len(substr) == 0 {
+		return 0
+	}
+	for i := 0; i <= len(s)-len(substr); i++ {
+		match := true
+		for j := 0; j < len(substr); j++ {
+			if s[i+j] != substr[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/plugin/manifest_io_test.go
+++ b/internal/plugin/manifest_io_test.go
@@ -1,0 +1,223 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadManifest(t *testing.T) {
+	content := `name: my-plugin
+version: 1.2.3
+author: test-author
+description: A test plugin for testing
+license: MIT
+homepage: https://example.com
+repository: https://github.com/example/my-plugin
+entry: main.go
+type: skill
+min_version: 0.14.0
+tags:
+  - testing
+  - demo
+dependencies:
+  - base-plugin@1.0.0
+permissions:
+  - filesystem
+  - network
+`
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "plugin.yaml")
+	os.WriteFile(path, []byte(content), 0644)
+
+	m, err := LoadManifest(path)
+	if err != nil {
+		t.Fatalf("LoadManifest() error = %v", err)
+	}
+
+	if m.Name != "my-plugin" {
+		t.Errorf("Name = %v, want my-plugin", m.Name)
+	}
+	if m.Version != "1.2.3" {
+		t.Errorf("Version = %v, want 1.2.3", m.Version)
+	}
+	if m.Author != "test-author" {
+		t.Errorf("Author = %v, want test-author", m.Author)
+	}
+	if m.Type != "skill" {
+		t.Errorf("Type = %v, want skill", m.Type)
+	}
+	if m.Entry != "main.go" {
+		t.Errorf("Entry = %v, want main.go", m.Entry)
+	}
+	if m.License != "MIT" {
+		t.Errorf("License = %v, want MIT", m.License)
+	}
+	if m.MinVersion != "0.14.0" {
+		t.Errorf("MinVersion = %v, want 0.14.0", m.MinVersion)
+	}
+	if len(m.Tags) != 2 || m.Tags[0] != "testing" || m.Tags[1] != "demo" {
+		t.Errorf("Tags = %v, want [testing, demo]", m.Tags)
+	}
+	if len(m.Dependencies) != 1 || m.Dependencies[0].Name != "base-plugin" {
+		t.Errorf("Dependencies = %v, want [base-plugin@1.0.0]", m.Dependencies)
+	}
+	if len(m.Permissions) != 2 {
+		t.Errorf("Permissions = %v, want 2 items", m.Permissions)
+	}
+}
+
+func TestSaveManifest(t *testing.T) {
+	m := &Manifest{
+		Name:        "test-plugin",
+		Version:     "1.0.0",
+		Author:      "test-author",
+		Description: "A test plugin",
+		Entry:       "main.go",
+		Type:        "skill",
+		Tags:        []string{"test"},
+		Permissions: []Permission{PermFileSystem},
+	}
+
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "plugin.yaml")
+
+	if err := SaveManifest(m, path); err != nil {
+		t.Fatalf("SaveManifest() error = %v", err)
+	}
+
+	// 验证文件存在
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Error("SaveManifest() did not create file")
+	}
+
+	// 重新加载验证
+	m2, err := LoadManifest(path)
+	if err != nil {
+		t.Fatalf("LoadManifest() after save error = %v", err)
+	}
+	if m2.Name != m.Name {
+		t.Errorf("Name = %v, want %v", m2.Name, m.Name)
+	}
+	if m2.Version != m.Version {
+		t.Errorf("Version = %v, want %v", m2.Version, m.Version)
+	}
+}
+
+func TestSaveManifestInvalid(t *testing.T) {
+	m := &Manifest{
+		// Name is missing
+		Version: "1.0.0",
+		Entry:   "main.go",
+		Type:    "skill",
+	}
+
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "plugin.yaml")
+
+	if err := SaveManifest(m, path); err == nil {
+		t.Error("SaveManifest() should fail for invalid manifest")
+	}
+}
+
+func TestLoadManifestNonexistent(t *testing.T) {
+	_, err := LoadManifest("/nonexistent/plugin.yaml")
+	if err == nil {
+		t.Error("LoadManifest() should fail for nonexistent file")
+	}
+}
+
+func TestFormatManifest(t *testing.T) {
+	m := &Manifest{
+		Name:        "test-plugin",
+		Version:     "1.0.0",
+		Author:      "test-author",
+		Description: "A test plugin",
+		Entry:       "main.go",
+		Type:        "skill",
+		Tags:        []string{"test", "demo"},
+		Dependencies: []Dependency{
+			{Name: "base", Version: "1.0.0"},
+		},
+		Permissions: []Permission{PermFileSystem, PermNetwork},
+	}
+
+	output := formatManifest(m)
+
+	// 验证关键行
+	if !containsString(output, "name: test-plugin") {
+		t.Error("formatManifest() missing name")
+	}
+	if !containsString(output, "version: 1.0.0") {
+		t.Error("formatManifest() missing version")
+	}
+	if !containsString(output, "type: skill") {
+		t.Error("formatManifest() missing type")
+	}
+	if !containsString(output, "- filesystem") {
+		t.Error("formatManifest() missing filesystem permission")
+	}
+	if !containsString(output, "- base@1.0.0") {
+		t.Error("formatManifest() missing dependency")
+	}
+}
+
+func TestParseKV(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantKey  string
+		wantVal  string
+		wantOk   bool
+	}{
+		{"name: my-plugin", "name", "my-plugin", true},
+		{"version: 1.0.0", "version", "1.0.0", true},
+		{`description: "A test plugin"`, "description", "A test plugin", true},
+		{"no-colon", "", "", false},
+		{"  spaced  :  value  ", "spaced", "value", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			key, val, ok := parseKV(tt.input)
+			if ok != tt.wantOk {
+				t.Errorf("parseKV() ok = %v, want %v", ok, tt.wantOk)
+			}
+			if ok && (key != tt.wantKey || val != tt.wantVal) {
+				t.Errorf("parseKV() = (%q, %q), want (%q, %q)", key, val, tt.wantKey, tt.wantVal)
+			}
+		})
+	}
+}
+
+func TestParseDependency(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantName string
+		wantVer  string
+	}{
+		{"base-plugin@1.0.0", "base-plugin", "1.0.0"},
+		{"base-plugin", "base-plugin", ""},
+		{"  spaced  @  2.0.0  ", "spaced", "2.0.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			dep := parseDependency(tt.input)
+			if dep.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", dep.Name, tt.wantName)
+			}
+			if dep.Version != tt.wantVer {
+				t.Errorf("Version = %q, want %q", dep.Version, tt.wantVer)
+			}
+		})
+	}
+}
+
+func containsString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -1,0 +1,387 @@
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Registry 插件注册中心
+type Registry struct {
+	mu       sync.RWMutex
+	plugins  map[string]*PluginEntry // name -> entry
+	pluginsDir string                 // 插件安装目录
+	index    *RemoteIndex             // 远程仓库索引（可选）
+}
+
+// PluginEntry 已安装的插件条目
+type PluginEntry struct {
+	Manifest  *Manifest
+	Status    PluginStatus
+	Config    map[string]any    // 插件配置
+	Error     string            // 错误信息（如果状态为 error）
+	UpdatedAt time.Time
+}
+
+// NewRegistry 创建插件注册中心
+func NewRegistry(pluginsDir string) *Registry {
+	return &Registry{
+		plugins:    make(map[string]*PluginEntry),
+		pluginsDir: pluginsDir,
+	}
+}
+
+// Register 注册插件
+func (r *Registry) Register(manifest *Manifest) error {
+	if err := manifest.Validate(); err != nil {
+		return fmt.Errorf("invalid manifest: %w", err)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.plugins[manifest.Name] = &PluginEntry{
+		Manifest:  manifest,
+		Status:    StatusInstalled,
+		Config:    make(map[string]any),
+		UpdatedAt: time.Now(),
+	}
+	return nil
+}
+
+// Unregister 注销插件
+func (r *Registry) Unregister(name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.plugins[name]; !ok {
+		return fmt.Errorf("plugin not found: %s", name)
+	}
+	delete(r.plugins, name)
+	return nil
+}
+
+// Get 获取插件
+func (r *Registry) Get(name string) (*PluginEntry, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	entry, ok := r.plugins[name]
+	if !ok {
+		return nil, false
+	}
+	return entry, true
+}
+
+// List 列出所有插件
+func (r *Registry) List() []*PluginEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	entries := make([]*PluginEntry, 0, len(r.plugins))
+	for _, e := range r.plugins {
+		entries = append(entries, e)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Manifest.Name < entries[j].Manifest.Name
+	})
+	return entries
+}
+
+// ListByType 按类型列出插件
+func (r *Registry) ListByType(pluginType string) []*PluginEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var entries []*PluginEntry
+	for _, e := range r.plugins {
+		if e.Manifest.Type == pluginType {
+			entries = append(entries, e)
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Manifest.Name < entries[j].Manifest.Name
+	})
+	return entries
+}
+
+// ListByStatus 按状态列出插件
+func (r *Registry) ListByStatus(status PluginStatus) []*PluginEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var entries []*PluginEntry
+	for _, e := range r.plugins {
+		if e.Status == status {
+			entries = append(entries, e)
+		}
+	}
+	return entries
+}
+
+// UpdateStatus 更新插件状态
+func (r *Registry) UpdateStatus(name string, status PluginStatus) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	entry, ok := r.plugins[name]
+	if !ok {
+		return fmt.Errorf("plugin not found: %s", name)
+	}
+	entry.Status = status
+	entry.UpdatedAt = time.Now()
+	return nil
+}
+
+// SetConfig 设置插件配置
+func (r *Registry) SetConfig(name string, key string, value any) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	entry, ok := r.plugins[name]
+	if !ok {
+		return fmt.Errorf("plugin not found: %s", name)
+	}
+	if entry.Config == nil {
+		entry.Config = make(map[string]any)
+	}
+	entry.Config[key] = value
+	entry.UpdatedAt = time.Now()
+	return nil
+}
+
+// GetConfig 获取插件配置
+func (r *Registry) GetConfig(name string, key string) (any, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	entry, ok := r.plugins[name]
+	if !ok {
+		return nil, false
+	}
+	if entry.Config == nil {
+		return nil, false
+	}
+	val, exists := entry.Config[key]
+	return val, exists
+}
+
+// SetError 设置插件错误状态
+func (r *Registry) SetError(name string, errMsg string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	entry, ok := r.plugins[name]
+	if !ok {
+		return
+	}
+	entry.Status = StatusError
+	entry.Error = errMsg
+	entry.UpdatedAt = time.Now()
+}
+
+// Count 返回插件数量
+func (r *Registry) Count() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.plugins)
+}
+
+// CountByType 按类型统计插件数量
+func (r *Registry) CountByType(pluginType string) int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	count := 0
+	for _, e := range r.plugins {
+		if e.Manifest.Type == pluginType {
+			count++
+		}
+	}
+	return count
+}
+
+// CheckDependencies 检查插件依赖是否满足
+func (r *Registry) CheckDependencies(manifest *Manifest) []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var missing []string
+	for _, dep := range manifest.Dependencies {
+		if _, ok := r.plugins[dep.Name]; !ok {
+			missing = append(missing, dep.Name)
+		}
+	}
+	return missing
+}
+
+// LoadFromDisk 从磁盘加载已安装的插件
+func (r *Registry) LoadFromDisk() error {
+	if r.pluginsDir == "" {
+		return nil
+	}
+
+	entries, err := os.ReadDir(r.pluginsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // 目录不存在，没有插件
+		}
+		return fmt.Errorf("read plugins dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		pluginDir := filepath.Join(r.pluginsDir, entry.Name())
+		manifestPath := filepath.Join(pluginDir, "plugin.yaml")
+
+		manifest, err := LoadManifest(manifestPath)
+		if err != nil {
+			// 记录错误但继续加载其他插件
+			r.mu.Lock()
+			r.plugins[entry.Name()] = &PluginEntry{
+				Manifest: &Manifest{
+					Name:  entry.Name(),
+					Type:  "unknown",
+				},
+				Status: StatusError,
+				Error:  fmt.Sprintf("load manifest: %v", err),
+			}
+			r.mu.Unlock()
+			continue
+		}
+
+		manifest.InstallPath = pluginDir
+		r.Register(manifest)
+	}
+
+	return nil
+}
+
+// RemoteIndex 远程仓库索引
+type RemoteIndex struct {
+	mu      sync.RWMutex
+	entries map[string]*RemoteEntry // name -> entry
+	url     string                  // 仓库 URL
+}
+
+// RemoteEntry 远程仓库中的插件条目
+type RemoteEntry struct {
+	Name        string   `json:"name"`
+	Version     string   `json:"version"`
+	Author      string   `json:"author"`
+	Description string   `json:"description"`
+	Type        string   `json:"type"`
+	Tags        []string `json:"tags"`
+	DownloadURL string   `json:"download_url"`
+	Checksum    string   `json:"checksum"`
+}
+
+// NewRemoteIndex 创建远程索引
+func NewRemoteIndex(url string) *RemoteIndex {
+	return &RemoteIndex{
+		entries: make(map[string]*RemoteEntry),
+		url:     url,
+	}
+}
+
+// Search 搜索远程仓库
+func (ri *RemoteIndex) Search(query string) []*RemoteEntry {
+	ri.mu.RLock()
+	defer ri.mu.RUnlock()
+
+	var results []*RemoteEntry
+	lowerQuery := fmt.Sprintf("%s", query)
+	for _, e := range ri.entries {
+		if matchRemoteEntry(e, lowerQuery) {
+			results = append(results, e)
+		}
+	}
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Name < results[j].Name
+	})
+	return results
+}
+
+// Get 获取远程插件信息
+func (ri *RemoteIndex) Get(name string) (*RemoteEntry, bool) {
+	ri.mu.RLock()
+	defer ri.mu.RUnlock()
+	e, ok := ri.entries[name]
+	return e, ok
+}
+
+// Add 添加远程插件条目
+func (ri *RemoteIndex) Add(entry *RemoteEntry) {
+	ri.mu.Lock()
+	defer ri.mu.Unlock()
+	ri.entries[entry.Name] = entry
+}
+
+// Count 返回远程插件数量
+func (ri *RemoteIndex) Count() int {
+	ri.mu.RLock()
+	defer ri.mu.RUnlock()
+	return len(ri.entries)
+}
+
+// matchRemoteEntry 检查远程条目是否匹配查询
+func matchRemoteEntry(e *RemoteEntry, query string) bool {
+	lower := stringsToLower(e.Name + " " + e.Description + " " + e.Author + " " + stringsJoin(e.Tags, " "))
+	return stringsContains(lower, query)
+}
+
+// helper to avoid importing strings package for simple ops
+func stringsToLower(s string) string {
+	result := make([]byte, len(s))
+	for i, ch := range s {
+		if ch >= 'A' && ch <= 'Z' {
+			result[i] = byte(ch + 32)
+		} else {
+			result[i] = byte(ch)
+		}
+	}
+	return string(result)
+}
+
+func stringsContains(s, substr string) bool {
+	return len(substr) == 0 || (len(s) >= len(substr) && findSubstring(s, substr))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		match := true
+		for j := 0; j < len(substr); j++ {
+			sc := s[i+j]
+			subc := substr[j]
+			if sc >= 'A' && sc <= 'Z' {
+				sc += 32
+			}
+			if subc >= 'A' && subc <= 'Z' {
+				subc += 32
+			}
+			if sc != subc {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+func stringsJoin(ss []string, sep string) string {
+	if len(ss) == 0 {
+		return ""
+	}
+	result := ss[0]
+	for _, s := range ss[1:] {
+		result += sep + s
+	}
+	return result
+}

--- a/internal/plugin/registry_test.go
+++ b/internal/plugin/registry_test.go
@@ -1,0 +1,431 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestManifestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		manifest *Manifest
+		wantErr bool
+	}{
+		{
+			name: "valid manifest",
+			manifest: &Manifest{
+				Name:    "my-plugin",
+				Version: "1.0.0",
+				Entry:   "main.go",
+				Type:    "skill",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing name",
+			manifest: &Manifest{
+				Version: "1.0.0",
+				Entry:   "main.go",
+				Type:    "skill",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing version",
+			manifest: &Manifest{
+				Name:  "my-plugin",
+				Entry: "main.go",
+				Type:  "skill",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing entry",
+			manifest: &Manifest{
+				Name:    "my-plugin",
+				Version: "1.0.0",
+				Type:    "skill",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing type",
+			manifest: &Manifest{
+				Name:    "my-plugin",
+				Version: "1.0.0",
+				Entry:   "main.go",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid type",
+			manifest: &Manifest{
+				Name:    "my-plugin",
+				Version: "1.0.0",
+				Entry:   "main.go",
+				Type:    "invalid",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid name with uppercase",
+			manifest: &Manifest{
+				Name:    "MyPlugin",
+				Version: "1.0.0",
+				Entry:   "main.go",
+				Type:    "skill",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid name with spaces",
+			manifest: &Manifest{
+				Name:    "my plugin",
+				Version: "1.0.0",
+				Entry:   "main.go",
+				Type:    "skill",
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid name with hyphens",
+			manifest: &Manifest{
+				Name:    "my-cool-plugin",
+				Version: "1.0.0",
+				Entry:   "main.go",
+				Type:    "tool",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid version format",
+			manifest: &Manifest{
+				Name:    "my-plugin",
+				Version: "1.0",
+				Entry:   "main.go",
+				Type:    "skill",
+			},
+			wantErr: true,
+		},
+		{
+			name: "provider type",
+			manifest: &Manifest{
+				Name:    "my-provider",
+				Version: "1.0.0",
+				Entry:   "main.go",
+				Type:    "provider",
+			},
+			wantErr: false,
+		},
+		{
+			name: "hook type",
+			manifest: &Manifest{
+				Name:    "my-hook",
+				Version: "1.0.0",
+				Entry:   "main.go",
+				Type:    "hook",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.manifest.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestManifestFullName(t *testing.T) {
+	m := &Manifest{Name: "my-plugin", Version: "1.2.3"}
+	if got := m.FullName(); got != "my-plugin@1.2.3" {
+		t.Errorf("FullName() = %v, want my-plugin@1.2.3", got)
+	}
+}
+
+func TestManifestHasPermission(t *testing.T) {
+	m := &Manifest{
+		Name:        "test-plugin",
+		Version:     "1.0.0",
+		Entry:       "main.go",
+		Type:        "skill",
+		Permissions: []Permission{PermFileSystem, PermNetwork},
+	}
+
+	if !m.HasPermission(PermFileSystem) {
+		t.Error("HasPermission(FileSystem) = false, want true")
+	}
+	if m.HasPermission(PermAdmin) {
+		t.Error("HasPermission(Admin) = true, want false")
+	}
+}
+
+func TestManifestHasDependency(t *testing.T) {
+	m := &Manifest{
+		Name:    "test-plugin",
+		Version: "1.0.0",
+		Entry:   "main.go",
+		Type:    "skill",
+		Dependencies: []Dependency{
+			{Name: "base-plugin", Version: "1.0.0"},
+		},
+	}
+
+	if !m.HasDependency("base-plugin") {
+		t.Error("HasDependency(base-plugin) = false, want true")
+	}
+	if m.HasDependency("nonexistent") {
+		t.Error("HasDependency(nonexistent) = true, want false")
+	}
+}
+
+func TestIsValidVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{"1.0.0", true},
+		{"0.1.0", true},
+		{"10.20.30", true},
+		{"1.0", false},
+		{"1", false},
+		{"", false},
+		{"v1.0.0", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			if got := isValidVersion(tt.version); got != tt.want {
+				t.Errorf("isValidVersion(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRegistryRegister(t *testing.T) {
+	reg := NewRegistry("")
+
+	m := &Manifest{
+		Name:    "test-plugin",
+		Version: "1.0.0",
+		Entry:   "main.go",
+		Type:    "skill",
+	}
+
+	if err := reg.Register(m); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	if reg.Count() != 1 {
+		t.Errorf("Count() = %d, want 1", reg.Count())
+	}
+
+	entry, ok := reg.Get("test-plugin")
+	if !ok {
+		t.Error("Get() not found")
+	}
+	if entry.Manifest.Version != "1.0.0" {
+		t.Errorf("Version = %v, want 1.0.0", entry.Manifest.Version)
+	}
+	if entry.Status != StatusInstalled {
+		t.Errorf("Status = %v, want installed", entry.Status)
+	}
+}
+
+func TestRegistryUnregister(t *testing.T) {
+	reg := NewRegistry("")
+
+	m := &Manifest{
+		Name:    "test-plugin",
+		Version: "1.0.0",
+		Entry:   "main.go",
+		Type:    "skill",
+	}
+
+	reg.Register(m)
+	if err := reg.Unregister("test-plugin"); err != nil {
+		t.Fatalf("Unregister() error = %v", err)
+	}
+
+	if reg.Count() != 0 {
+		t.Errorf("Count() = %d, want 0", reg.Count())
+	}
+
+	if err := reg.Unregister("nonexistent"); err == nil {
+		t.Error("Unregister(nonexistent) should return error")
+	}
+}
+
+func TestRegistryListByType(t *testing.T) {
+	reg := NewRegistry("")
+
+	reg.Register(&Manifest{Name: "p1", Version: "1.0.0", Entry: "main.go", Type: "skill"})
+	reg.Register(&Manifest{Name: "p2", Version: "1.0.0", Entry: "main.go", Type: "tool"})
+	reg.Register(&Manifest{Name: "p3", Version: "1.0.0", Entry: "main.go", Type: "skill"})
+
+	skills := reg.ListByType("skill")
+	if len(skills) != 2 {
+		t.Errorf("ListByType(skill) = %d, want 2", len(skills))
+	}
+
+	tools := reg.ListByType("tool")
+	if len(tools) != 1 {
+		t.Errorf("ListByType(tool) = %d, want 1", len(tools))
+	}
+}
+
+func TestRegistryUpdateStatus(t *testing.T) {
+	reg := NewRegistry("")
+
+	reg.Register(&Manifest{Name: "test-plugin", Version: "1.0.0", Entry: "main.go", Type: "skill"})
+
+	if err := reg.UpdateStatus("test-plugin", StatusDisabled); err != nil {
+		t.Fatalf("UpdateStatus() error = %v", err)
+	}
+
+	entry, _ := reg.Get("test-plugin")
+	if entry.Status != StatusDisabled {
+		t.Errorf("Status = %v, want disabled", entry.Status)
+	}
+
+	if err := reg.UpdateStatus("nonexistent", StatusInstalled); err == nil {
+		t.Error("UpdateStatus(nonexistent) should return error")
+	}
+}
+
+func TestRegistrySetConfig(t *testing.T) {
+	reg := NewRegistry("")
+
+	reg.Register(&Manifest{Name: "test-plugin", Version: "1.0.0", Entry: "main.go", Type: "skill"})
+
+	if err := reg.SetConfig("test-plugin", "key1", "value1"); err != nil {
+		t.Fatalf("SetConfig() error = %v", err)
+	}
+
+	val, ok := reg.GetConfig("test-plugin", "key1")
+	if !ok || val != "value1" {
+		t.Errorf("GetConfig() = %v, want value1", val)
+	}
+
+	_, ok = reg.GetConfig("test-plugin", "nonexistent")
+	if ok {
+		t.Error("GetConfig(nonexistent) should return false")
+	}
+}
+
+func TestRegistryCheckDependencies(t *testing.T) {
+	reg := NewRegistry("")
+
+	reg.Register(&Manifest{Name: "base-plugin", Version: "1.0.0", Entry: "main.go", Type: "skill"})
+
+	m := &Manifest{
+		Name:    "dependent-plugin",
+		Version: "1.0.0",
+		Entry:   "main.go",
+		Type:    "skill",
+		Dependencies: []Dependency{
+			{Name: "base-plugin"},
+			{Name: "missing-plugin"},
+		},
+	}
+
+	missing := reg.CheckDependencies(m)
+	if len(missing) != 1 || missing[0] != "missing-plugin" {
+		t.Errorf("CheckDependencies() = %v, want [missing-plugin]", missing)
+	}
+}
+
+func TestRegistryLoadFromDisk(t *testing.T) {
+	// 创建临时目录
+	tmpDir := t.TempDir()
+	pluginsDir := filepath.Join(tmpDir, "plugins")
+	os.MkdirAll(pluginsDir, 0755)
+
+	// 创建测试插件
+	pluginDir := filepath.Join(pluginsDir, "test-plugin")
+	os.MkdirAll(pluginDir, 0755)
+
+	manifestContent := `name: test-plugin
+version: 1.0.0
+author: test-author
+description: A test plugin
+entry: main.go
+type: skill
+permissions:
+  - filesystem
+  - network
+`
+	os.WriteFile(filepath.Join(pluginDir, "plugin.yaml"), []byte(manifestContent), 0644)
+
+	reg := NewRegistry(pluginsDir)
+	if err := reg.LoadFromDisk(); err != nil {
+		t.Fatalf("LoadFromDisk() error = %v", err)
+	}
+
+	if reg.Count() != 1 {
+		t.Errorf("Count() = %d, want 1", reg.Count())
+	}
+
+	entry, ok := reg.Get("test-plugin")
+	if !ok {
+		t.Error("Get(test-plugin) not found")
+	}
+	if entry.Manifest.Author != "test-author" {
+		t.Errorf("Author = %v, want test-author", entry.Manifest.Author)
+	}
+	if entry.Manifest.Type != "skill" {
+		t.Errorf("Type = %v, want skill", entry.Manifest.Type)
+	}
+}
+
+func TestRegistryLoadFromDiskEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	pluginsDir := filepath.Join(tmpDir, "plugins")
+
+	reg := NewRegistry(pluginsDir)
+	// 目录不存在时不应报错
+	if err := reg.LoadFromDisk(); err != nil {
+		t.Fatalf("LoadFromDisk() on nonexistent dir error = %v", err)
+	}
+	if reg.Count() != 0 {
+		t.Errorf("Count() = %d, want 0", reg.Count())
+	}
+}
+
+func TestRegistrySetError(t *testing.T) {
+	reg := NewRegistry("")
+
+	reg.Register(&Manifest{Name: "test-plugin", Version: "1.0.0", Entry: "main.go", Type: "skill"})
+
+	reg.SetError("test-plugin", "something went wrong")
+
+	entry, _ := reg.Get("test-plugin")
+	if entry.Status != StatusError {
+		t.Errorf("Status = %v, want error", entry.Status)
+	}
+	if entry.Error != "something went wrong" {
+		t.Errorf("Error = %v, want 'something went wrong'", entry.Error)
+	}
+}
+
+func TestRegistryCountByType(t *testing.T) {
+	reg := NewRegistry("")
+
+	reg.Register(&Manifest{Name: "p1", Version: "1.0.0", Entry: "main.go", Type: "skill"})
+	reg.Register(&Manifest{Name: "p2", Version: "1.0.0", Entry: "main.go", Type: "skill"})
+	reg.Register(&Manifest{Name: "p3", Version: "1.0.0", Entry: "main.go", Type: "tool"})
+
+	if got := reg.CountByType("skill"); got != 2 {
+		t.Errorf("CountByType(skill) = %d, want 2", got)
+	}
+	if got := reg.CountByType("tool"); got != 1 {
+		t.Errorf("CountByType(tool) = %d, want 1", got)
+	}
+	if got := reg.CountByType("provider"); got != 0 {
+		t.Errorf("CountByType(provider) = %d, want 0", got)
+	}
+}

--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -1,0 +1,273 @@
+package plugin
+
+import (
+	"fmt"
+	"time"
+)
+
+// Sandbox 插件沙箱 — 权限控制 + 资源限制
+type Sandbox struct {
+	mu       map[string]*SandboxConfig // plugin name -> config
+	limits   ResourceLimits             // 全局默认限制
+	enforcer PermissionEnforcer        // 权限执行器
+}
+
+// SandboxConfig 插件沙箱配置
+type SandboxConfig struct {
+	Permissions []Permission   // 允许的权限
+	Limits      ResourceLimits // 资源限制
+	Restricted  bool           // 是否为受限模式（默认 true）
+}
+
+// ResourceLimits 资源限制
+type ResourceLimits struct {
+	MaxMemoryMB     int           // 最大内存（MB）
+	MaxCPUPercent   int           // 最大 CPU 使用率（%）
+	MaxGoroutines   int           // 最大并发 goroutine 数
+	Timeout         time.Duration // 执行超时
+	MaxOutputBytes  int           // 最大输出字节数
+	MaxCallsPerMin  int           // 每分钟最大调用次数
+}
+
+// DefaultResourceLimits 默认资源限制
+func DefaultResourceLimits() ResourceLimits {
+	return ResourceLimits{
+		MaxMemoryMB:    256,
+		MaxCPUPercent:  50,
+		MaxGoroutines:  10,
+		Timeout:        30 * time.Second,
+		MaxOutputBytes: 1024 * 1024, // 1MB
+		MaxCallsPerMin: 60,
+	}
+}
+
+// PermissionEnforcer 权限执行器接口
+type PermissionEnforcer interface {
+	// CheckPermission 检查插件是否有指定权限
+	CheckPermission(pluginName string, perm Permission) error
+	// CheckRateLimit 检查调用频率限制
+	CheckRateLimit(pluginName string) error
+	// CheckResourceLimit 检查资源限制
+	CheckResourceLimit(pluginName string, resource string, amount int) error
+}
+
+// DefaultEnforcer 默认权限执行器
+type DefaultEnforcer struct {
+	callCounts map[string]*callCounter
+}
+
+type callCounter struct {
+	counts   []time.Time
+	maxPerMin int
+}
+
+// NewSandbox 创建插件沙箱
+func NewSandbox(limits ResourceLimits) *Sandbox {
+	return &Sandbox{
+		mu:       make(map[string]*SandboxConfig),
+		limits:   limits,
+		enforcer: &DefaultEnforcer{callCounts: make(map[string]*callCounter)},
+	}
+}
+
+// NewDefaultSandbox 创建默认沙箱
+func NewDefaultSandbox() *Sandbox {
+	return NewSandbox(DefaultResourceLimits())
+}
+
+// RegisterPlugin 为插件注册沙箱配置
+func (s *Sandbox) RegisterPlugin(name string, manifest *Manifest) {
+	config := &SandboxConfig{
+		Permissions: manifest.Permissions,
+		Limits:      s.limits,
+		Restricted:  true,
+	}
+	s.mu[name] = config
+}
+
+// UnregisterPlugin 注销插件的沙箱配置
+func (s *Sandbox) UnregisterPlugin(name string) {
+	delete(s.mu, name)
+}
+
+// CheckPermission 检查插件是否有指定权限
+func (s *Sandbox) CheckPermission(pluginName string, perm Permission) error {
+	config, ok := s.mu[pluginName]
+	if !ok {
+		return fmt.Errorf("plugin not in sandbox: %s", pluginName)
+	}
+
+	// admin 权限始终需要显式声明
+	if perm == PermAdmin {
+		for _, p := range config.Permissions {
+			if p == PermAdmin {
+				return nil
+			}
+		}
+		return fmt.Errorf("plugin %s does not have admin permission", pluginName)
+	}
+
+	// 检查权限列表
+	for _, p := range config.Permissions {
+		if p == perm {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("plugin %s does not have %s permission", pluginName, perm)
+}
+
+// CheckRateLimit 检查调用频率限制
+func (s *Sandbox) CheckRateLimit(pluginName string) error {
+	config, ok := s.mu[pluginName]
+	if !ok {
+		return fmt.Errorf("plugin not in sandbox: %s", pluginName)
+	}
+
+	// 简单的频率限制检查（实际实现需要更精确的滑动窗口）
+	// 这里只做接口定义，具体逻辑由 enforcer 实现
+	_ = config.Limits.MaxCallsPerMin
+	return nil
+}
+
+// GetLimits 获取插件的资源限制
+func (s *Sandbox) GetLimits(pluginName string) (ResourceLimits, error) {
+	config, ok := s.mu[pluginName]
+	if !ok {
+		return ResourceLimits{}, fmt.Errorf("plugin not in sandbox: %s", pluginName)
+	}
+	return config.Limits, nil
+}
+
+// SetLimits 设置插件的资源限制
+func (s *Sandbox) SetLimits(pluginName string, limits ResourceLimits) error {
+	config, ok := s.mu[pluginName]
+	if !ok {
+		return fmt.Errorf("plugin not in sandbox: %s", pluginName)
+	}
+	config.Limits = limits
+	return nil
+}
+
+// IsRestricted 检查插件是否为受限模式
+func (s *Sandbox) IsRestricted(pluginName string) bool {
+	config, ok := s.mu[pluginName]
+	if !ok {
+		return true // 未知插件默认受限
+	}
+	return config.Restricted
+}
+
+// SetRestricted 设置插件受限模式
+func (s *Sandbox) SetRestricted(pluginName string, restricted bool) error {
+	config, ok := s.mu[pluginName]
+	if !ok {
+		return fmt.Errorf("plugin not in sandbox: %s", pluginName)
+	}
+	config.Restricted = restricted
+	return nil
+}
+
+// GrantPermission 授予插件额外权限
+func (s *Sandbox) GrantPermission(pluginName string, perm Permission) error {
+	config, ok := s.mu[pluginName]
+	if !ok {
+		return fmt.Errorf("plugin not in sandbox: %s", pluginName)
+	}
+
+	// 检查是否已有
+	for _, p := range config.Permissions {
+		if p == perm {
+			return nil // 已有
+		}
+	}
+
+	config.Permissions = append(config.Permissions, perm)
+	return nil
+}
+
+// RevokePermission 撤销插件权限
+func (s *Sandbox) RevokePermission(pluginName string, perm Permission) error {
+	config, ok := s.mu[pluginName]
+	if !ok {
+		return fmt.Errorf("plugin not in sandbox: %s", pluginName)
+	}
+
+	newPerms := make([]Permission, 0, len(config.Permissions))
+	for _, p := range config.Permissions {
+		if p != perm {
+			newPerms = append(newPerms, p)
+		}
+	}
+	config.Permissions = newPerms
+	return nil
+}
+
+// GetPermissions 获取插件的所有权限
+func (s *Sandbox) GetPermissions(pluginName string) ([]Permission, error) {
+	config, ok := s.mu[pluginName]
+	if !ok {
+		return nil, fmt.Errorf("plugin not in sandbox: %s", pluginName)
+	}
+	return config.Permissions, nil
+}
+
+// --- DefaultEnforcer 实现 ---
+
+// CheckPermission 实现 PermissionEnforcer
+func (de *DefaultEnforcer) CheckPermission(pluginName string, perm Permission) error {
+	// 默认执行器不做实际检查，由 Sandbox 管理
+	return nil
+}
+
+// CheckRateLimit 实现 PermissionEnforcer
+func (de *DefaultEnforcer) CheckRateLimit(pluginName string) error {
+	// 简单的频率限制实现
+	counter, ok := de.callCounts[pluginName]
+	if !ok {
+		counter = &callCounter{maxPerMin: 60}
+		de.callCounts[pluginName] = counter
+	}
+
+	now := time.Now()
+	// 清理超过1分钟的记录
+	var recent []time.Time
+	for _, t := range counter.counts {
+		if now.Sub(t) < time.Minute {
+			recent = append(recent, t)
+		}
+	}
+	counter.counts = recent
+
+	if len(counter.counts) >= counter.maxPerMin {
+		return fmt.Errorf("rate limit exceeded for plugin %s", pluginName)
+	}
+
+	counter.counts = append(counter.counts, now)
+	return nil
+}
+
+// CheckResourceLimit 实现 PermissionEnforcer
+func (de *DefaultEnforcer) CheckResourceLimit(pluginName string, resource string, amount int) error {
+	// 默认不做实际限制检查
+	return nil
+}
+
+// FormatPermissions 格式化权限列表为文本
+func FormatPermissions(perms []Permission) string {
+	if len(perms) == 0 {
+		return "(none)"
+	}
+	names := make([]string, len(perms))
+	for i, p := range perms {
+		names[i] = string(p)
+	}
+	result := ""
+	for i, n := range names {
+		if i > 0 {
+			result += ", "
+		}
+		result += n
+	}
+	return result
+}

--- a/internal/plugin/sandbox_test.go
+++ b/internal/plugin/sandbox_test.go
@@ -1,0 +1,299 @@
+package plugin
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewSandbox(t *testing.T) {
+	limits := DefaultResourceLimits()
+	sandbox := NewSandbox(limits)
+
+	if sandbox == nil {
+		t.Error("NewSandbox() returned nil")
+	}
+	if sandbox.limits.MaxMemoryMB != 256 {
+		t.Errorf("MaxMemoryMB = %d, want 256", sandbox.limits.MaxMemoryMB)
+	}
+	if sandbox.limits.MaxCallsPerMin != 60 {
+		t.Errorf("MaxCallsPerMin = %d, want 60", sandbox.limits.MaxCallsPerMin)
+	}
+}
+
+func TestNewDefaultSandbox(t *testing.T) {
+	sandbox := NewDefaultSandbox()
+	if sandbox == nil {
+		t.Error("NewDefaultSandbox() returned nil")
+	}
+}
+
+func TestSandboxRegisterPlugin(t *testing.T) {
+	sandbox := NewDefaultSandbox()
+
+	m := &Manifest{
+		Name:        "test-plugin",
+		Version:     "1.0.0",
+		Entry:       "main.go",
+		Type:        "skill",
+		Permissions: []Permission{PermFileSystem, PermNetwork},
+	}
+
+	sandbox.RegisterPlugin("test-plugin", m)
+
+	// 验证权限检查
+	if err := sandbox.CheckPermission("test-plugin", PermFileSystem); err != nil {
+		t.Errorf("CheckPermission(FileSystem) error = %v", err)
+	}
+	if err := sandbox.CheckPermission("test-plugin", PermNetwork); err != nil {
+		t.Errorf("CheckPermission(Network) error = %v", err)
+	}
+	if err := sandbox.CheckPermission("test-plugin", PermAdmin); err == nil {
+		t.Error("CheckPermission(Admin) should fail without admin permission")
+	}
+	if err := sandbox.CheckPermission("test-plugin", PermRAG); err == nil {
+		t.Error("CheckPermission(RAG) should fail without RAG permission")
+	}
+}
+
+func TestSandboxCheckPermissionNotRegistered(t *testing.T) {
+	sandbox := NewDefaultSandbox()
+
+	err := sandbox.CheckPermission("nonexistent", PermFileSystem)
+	if err == nil {
+		t.Error("CheckPermission for unregistered plugin should fail")
+	}
+}
+
+func TestSandboxGrantRevokePermission(t *testing.T) {
+	sandbox := NewDefaultSandbox()
+
+	m := &Manifest{
+		Name:        "test-plugin",
+		Version:     "1.0.0",
+		Entry:       "main.go",
+		Type:        "skill",
+		Permissions: []Permission{PermFileSystem},
+	}
+
+	sandbox.RegisterPlugin("test-plugin", m)
+
+	// 授予额外权限
+	if err := sandbox.GrantPermission("test-plugin", PermNetwork); err != nil {
+		t.Fatalf("GrantPermission() error = %v", err)
+	}
+
+	perms, err := sandbox.GetPermissions("test-plugin")
+	if err != nil {
+		t.Fatalf("GetPermissions() error = %v", err)
+	}
+	if len(perms) != 2 {
+		t.Errorf("len(Permissions) = %d, want 2", len(perms))
+	}
+
+	// 撤销权限
+	if err := sandbox.RevokePermission("test-plugin", PermNetwork); err != nil {
+		t.Fatalf("RevokePermission() error = %v", err)
+	}
+
+	perms, _ = sandbox.GetPermissions("test-plugin")
+	if len(perms) != 1 {
+		t.Errorf("len(Permissions) after revoke = %d, want 1", len(perms))
+	}
+
+	// 重复授予不应报错
+	if err := sandbox.GrantPermission("test-plugin", PermFileSystem); err != nil {
+		t.Fatalf("GrantPermission() duplicate error = %v", err)
+	}
+}
+
+func TestSandboxIsRestricted(t *testing.T) {
+	sandbox := NewDefaultSandbox()
+
+	m := &Manifest{
+		Name:    "test-plugin",
+		Version: "1.0.0",
+		Entry:   "main.go",
+		Type:    "skill",
+	}
+
+	sandbox.RegisterPlugin("test-plugin", m)
+
+	if !sandbox.IsRestricted("test-plugin") {
+		t.Error("IsRestricted() = false, want true (default)")
+	}
+
+	if err := sandbox.SetRestricted("test-plugin", false); err != nil {
+		t.Fatalf("SetRestricted() error = %v", err)
+	}
+
+	if sandbox.IsRestricted("test-plugin") {
+		t.Error("IsRestricted() = true after SetRestricted(false)")
+	}
+}
+
+func TestSandboxGetSetLimits(t *testing.T) {
+	sandbox := NewDefaultSandbox()
+
+	m := &Manifest{
+		Name:    "test-plugin",
+		Version: "1.0.0",
+		Entry:   "main.go",
+		Type:    "skill",
+	}
+
+	sandbox.RegisterPlugin("test-plugin", m)
+
+	limits, err := sandbox.GetLimits("test-plugin")
+	if err != nil {
+		t.Fatalf("GetLimits() error = %v", err)
+	}
+	if limits.MaxMemoryMB != 256 {
+		t.Errorf("MaxMemoryMB = %d, want 256", limits.MaxMemoryMB)
+	}
+
+	newLimits := ResourceLimits{
+		MaxMemoryMB:    512,
+		MaxCPUPercent:  80,
+		MaxGoroutines:  20,
+		Timeout:        60 * time.Second,
+		MaxOutputBytes: 2 * 1024 * 1024,
+		MaxCallsPerMin: 120,
+	}
+
+	if err := sandbox.SetLimits("test-plugin", newLimits); err != nil {
+		t.Fatalf("SetLimits() error = %v", err)
+	}
+
+	updatedLimits, _ := sandbox.GetLimits("test-plugin")
+	if updatedLimits.MaxMemoryMB != 512 {
+		t.Errorf("MaxMemoryMB after update = %d, want 512", updatedLimits.MaxMemoryMB)
+	}
+}
+
+func TestSandboxUnregisterPlugin(t *testing.T) {
+	sandbox := NewDefaultSandbox()
+
+	m := &Manifest{
+		Name:    "test-plugin",
+		Version: "1.0.0",
+		Entry:   "main.go",
+		Type:    "skill",
+	}
+
+	sandbox.RegisterPlugin("test-plugin", m)
+	sandbox.UnregisterPlugin("test-plugin")
+
+	// 注销后应该找不到
+	if !sandbox.IsRestricted("test-plugin") {
+		t.Error("IsRestricted() for unregistered plugin should return true")
+	}
+}
+
+func TestSandboxNotRegisteredErrors(t *testing.T) {
+	sandbox := NewDefaultSandbox()
+
+	if err := sandbox.SetRestricted("nonexistent", false); err == nil {
+		t.Error("SetRestricted for unregistered plugin should fail")
+	}
+
+	if err := sandbox.SetLimits("nonexistent", ResourceLimits{}); err == nil {
+		t.Error("SetLimits for unregistered plugin should fail")
+	}
+
+	_, err := sandbox.GetLimits("nonexistent")
+	if err == nil {
+		t.Error("GetLimits for unregistered plugin should fail")
+	}
+
+	_, err = sandbox.GetPermissions("nonexistent")
+	if err == nil {
+		t.Error("GetPermissions for unregistered plugin should fail")
+	}
+}
+
+func TestFormatPermissions(t *testing.T) {
+	tests := []struct {
+		perms []Permission
+		want  string
+	}{
+		{nil, "(none)"},
+		{[]Permission{}, "(none)"},
+		{[]Permission{PermFileSystem}, "filesystem"},
+		{[]Permission{PermFileSystem, PermNetwork}, "filesystem, network"},
+	}
+
+	for _, tt := range tests {
+		got := FormatPermissions(tt.perms)
+		if got != tt.want {
+			t.Errorf("FormatPermissions(%v) = %q, want %q", tt.perms, got, tt.want)
+		}
+	}
+}
+
+func TestDefaultEnforcerRateLimit(t *testing.T) {
+	enforcer := &DefaultEnforcer{
+		callCounts: make(map[string]*callCounter),
+	}
+
+	// 正常调用不应报错
+	for i := 0; i < 5; i++ {
+		if err := enforcer.CheckRateLimit("test-plugin"); err != nil {
+			t.Errorf("CheckRateLimit() call %d error = %v", i, err)
+		}
+	}
+}
+
+func TestRemoteIndex(t *testing.T) {
+	index := NewRemoteIndex("https://example.com/plugins")
+
+	// 添加条目
+	index.Add(&RemoteEntry{
+		Name:        "web-search",
+		Version:     "1.0.0",
+		Author:      "luckyharness",
+		Description: "Web search plugin",
+		Type:        "tool",
+		Tags:        []string{"search", "web"},
+		DownloadURL: "https://example.com/plugins/web-search-1.0.0.zip",
+	})
+
+	index.Add(&RemoteEntry{
+		Name:        "code-review",
+		Version:     "2.1.0",
+		Author:      "luckyharness",
+		Description: "Code review assistant",
+		Type:        "skill",
+		Tags:        []string{"code", "review"},
+		DownloadURL: "https://example.com/plugins/code-review-2.1.0.zip",
+	})
+
+	if index.Count() != 2 {
+		t.Errorf("Count() = %d, want 2", index.Count())
+	}
+
+	// 获取
+	entry, ok := index.Get("web-search")
+	if !ok {
+		t.Error("Get(web-search) not found")
+	}
+	if entry.Version != "1.0.0" {
+		t.Errorf("Version = %v, want 1.0.0", entry.Version)
+	}
+
+	// 搜索
+	results := index.Search("search")
+	if len(results) != 1 {
+		t.Errorf("Search(search) = %d results, want 1", len(results))
+	}
+
+	results = index.Search("code")
+	if len(results) != 1 {
+		t.Errorf("Search(code) = %d results, want 1", len(results))
+	}
+
+	// 不存在的搜索
+	results = index.Search("nonexistent")
+	if len(results) != 0 {
+		t.Errorf("Search(nonexistent) = %d results, want 0", len(results))
+	}
+}

--- a/internal/server/plugin_handlers.go
+++ b/internal/server/plugin_handlers.go
@@ -1,0 +1,429 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/yurika0211/luckyharness/internal/config"
+	"github.com/yurika0211/luckyharness/internal/plugin"
+)
+
+// ===== v0.15.0: Plugin API 端点 =====
+
+// handlePlugins 插件列表
+// GET /api/v1/plugins
+func (s *Server) handlePlugins(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		s.sendJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	reg, _, _, err := s.getPluginDeps()
+	if err != nil {
+		s.sendJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	// 过滤参数
+	pluginType := r.URL.Query().Get("type")
+	status := r.URL.Query().Get("status")
+
+	var plugins []*plugin.PluginEntry
+	if pluginType != "" {
+		plugins = reg.ListByType(pluginType)
+	} else if status != "" {
+		plugins = reg.ListByStatus(plugin.PluginStatus(status))
+	} else {
+		plugins = reg.List()
+	}
+
+	type pluginJSON struct {
+		Name        string `json:"name"`
+		Version     string `json:"version"`
+		Type        string `json:"type"`
+		Author      string `json:"author"`
+		Description string `json:"description"`
+		Status      string `json:"status"`
+		InstallPath string `json:"install_path,omitempty"`
+	}
+
+	result := make([]pluginJSON, 0, len(plugins))
+	for _, p := range plugins {
+		result = append(result, pluginJSON{
+			Name:        p.Manifest.Name,
+			Version:     p.Manifest.Version,
+			Type:        p.Manifest.Type,
+			Author:      p.Manifest.Author,
+			Description: p.Manifest.Description,
+			Status:      string(p.Status),
+			InstallPath: p.Manifest.InstallPath,
+		})
+	}
+
+	s.sendJSON(w, http.StatusOK, map[string]any{
+		"plugins": result,
+		"count":   len(result),
+	})
+}
+
+// handlePluginGet 获取单个插件详情
+// GET /api/v1/plugins/{name}
+func (s *Server) handlePluginGet(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		s.sendJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	name := extractPathSuffix(r.URL.Path, "/api/v1/plugins/")
+	if name == "" {
+		s.sendJSON(w, http.StatusBadRequest, map[string]string{"error": "plugin name required"})
+		return
+	}
+
+	reg, _, sandbox, err := s.getPluginDeps()
+	if err != nil {
+		s.sendJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	entry, ok := reg.Get(name)
+	if !ok {
+		s.sendJSON(w, http.StatusNotFound, map[string]string{"error": "plugin not found"})
+		return
+	}
+
+	m := entry.Manifest
+	perms, _ := sandbox.GetPermissions(name)
+
+	type depJSON struct {
+		Name    string `json:"name"`
+		Version string `json:"version,omitempty"`
+	}
+
+	deps := make([]depJSON, 0, len(m.Dependencies))
+	for _, d := range m.Dependencies {
+		deps = append(deps, depJSON{Name: d.Name, Version: d.Version})
+	}
+
+	permStrs := make([]string, 0, len(perms))
+	for _, p := range perms {
+		permStrs = append(permStrs, string(p))
+	}
+
+	s.sendJSON(w, http.StatusOK, map[string]any{
+		"name":         m.Name,
+		"version":      m.Version,
+		"type":         m.Type,
+		"author":       m.Author,
+		"description":  m.Description,
+		"license":      m.License,
+		"homepage":     m.Homepage,
+		"repository":   m.Repository,
+		"entry":        m.Entry,
+		"min_version":  m.MinVersion,
+		"tags":         m.Tags,
+		"dependencies": deps,
+		"permissions":  permStrs,
+		"status":       string(entry.Status),
+		"install_path": m.InstallPath,
+		"error":        entry.Error,
+	})
+}
+
+// handlePluginInstall 安装插件
+// POST /api/v1/plugins/install
+func (s *Server) handlePluginInstall(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		s.sendJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	var req struct {
+		Path string `json:"path"` // 本地路径
+		URL  string `json:"url"`  // 远程 URL（暂不支持）
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.sendJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	if req.Path == "" {
+		s.sendJSON(w, http.StatusBadRequest, map[string]string{"error": "path is required"})
+		return
+	}
+
+	reg, inst, sandbox, err := s.getPluginDeps()
+	if err != nil {
+		s.sendJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	result, err := inst.Install(req.Path)
+	if err != nil {
+		s.sendJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	// 注册沙箱
+	entry, _ := reg.Get(result.Name)
+	if entry != nil {
+		sandbox.RegisterPlugin(result.Name, entry.Manifest)
+	}
+
+	s.sendJSON(w, http.StatusOK, map[string]any{
+		"name":       result.Name,
+		"version":    result.Version,
+		"installed":  result.Installed,
+		"updated":    result.Updated,
+		"installDir": result.InstallDir,
+	})
+}
+
+// handlePluginUninstall 卸载插件
+// DELETE /api/v1/plugins/{name}
+func (s *Server) handlePluginUninstall(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		s.sendJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	name := extractPathSuffix(r.URL.Path, "/api/v1/plugins/")
+	if name == "" {
+		s.sendJSON(w, http.StatusBadRequest, map[string]string{"error": "plugin name required"})
+		return
+	}
+
+	_, inst, _, err := s.getPluginDeps()
+	if err != nil {
+		s.sendJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	if err := inst.Uninstall(name); err != nil {
+		s.sendJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		return
+	}
+
+	s.sendJSON(w, http.StatusOK, map[string]string{"status": "uninstalled", "name": name})
+}
+
+// handlePluginSearch 搜索插件
+// GET /api/v1/plugins/search?q=xxx
+func (s *Server) handlePluginSearch(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		s.sendJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	query := r.URL.Query().Get("q")
+	if query == "" {
+		s.sendJSON(w, http.StatusBadRequest, map[string]string{"error": "query parameter 'q' is required"})
+		return
+	}
+
+	reg, _, _, err := s.getPluginDeps()
+	if err != nil {
+		s.sendJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	// 搜索本地已安装的插件
+	plugins := reg.List()
+	type pluginJSON struct {
+		Name        string `json:"name"`
+		Version     string `json:"version"`
+		Type        string `json:"type"`
+		Description string `json:"description"`
+		Author      string `json:"author"`
+	}
+
+	var results []pluginJSON
+	lowerQuery := strings.ToLower(query)
+	for _, p := range plugins {
+		if strings.Contains(strings.ToLower(p.Manifest.Name), lowerQuery) ||
+			strings.Contains(strings.ToLower(p.Manifest.Description), lowerQuery) ||
+			strings.Contains(strings.ToLower(p.Manifest.Author), lowerQuery) {
+			results = append(results, pluginJSON{
+				Name:        p.Manifest.Name,
+				Version:     p.Manifest.Version,
+				Type:        p.Manifest.Type,
+				Description: p.Manifest.Description,
+				Author:      p.Manifest.Author,
+			})
+		}
+	}
+
+	s.sendJSON(w, http.StatusOK, map[string]any{
+		"query":  query,
+		"results": results,
+		"count":   len(results),
+	})
+}
+
+// handlePluginToggle 启用/禁用插件
+// POST /api/v1/plugins/{name}/enable
+// POST /api/v1/plugins/{name}/disable
+func (s *Server) handlePluginToggle(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		s.sendJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	path := r.URL.Path
+	enable := strings.HasSuffix(path, "/enable")
+	disable := strings.HasSuffix(path, "/disable")
+
+	if !enable && !disable {
+		s.sendJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid action, use /enable or /disable"})
+		return
+	}
+
+	// 提取插件名
+	var name string
+	if enable {
+		name = strings.TrimSuffix(extractPathSuffix(path, "/api/v1/plugins/"), "/enable")
+	} else {
+		name = strings.TrimSuffix(extractPathSuffix(path, "/api/v1/plugins/"), "/disable")
+	}
+
+	if name == "" {
+		s.sendJSON(w, http.StatusBadRequest, map[string]string{"error": "plugin name required"})
+		return
+	}
+
+	reg, _, _, err := s.getPluginDeps()
+	if err != nil {
+		s.sendJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	var status plugin.PluginStatus
+	var action string
+	if enable {
+		status = plugin.StatusInstalled
+		action = "enabled"
+	} else {
+		status = plugin.StatusDisabled
+		action = "disabled"
+	}
+
+	if err := reg.UpdateStatus(name, status); err != nil {
+		s.sendJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		return
+	}
+
+	s.sendJSON(w, http.StatusOK, map[string]string{
+		"name":   name,
+		"status": action,
+	})
+}
+
+// handlePluginPermissions 管理插件权限
+// GET /api/v1/plugins/{name}/permissions
+// POST /api/v1/plugins/{name}/permissions (grant/revoke)
+func (s *Server) handlePluginPermissions(w http.ResponseWriter, r *http.Request) {
+	_, _, sandbox, err := s.getPluginDeps()
+	if err != nil {
+		s.sendJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	// 提取插件名
+	name := extractPathSuffix(r.URL.Path, "/api/v1/plugins/")
+	name = strings.TrimSuffix(name, "/permissions")
+	name = strings.TrimSuffix(name, "/perms")
+
+	if name == "" {
+		s.sendJSON(w, http.StatusBadRequest, map[string]string{"error": "plugin name required"})
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		perms, err := sandbox.GetPermissions(name)
+		if err != nil {
+			s.sendJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+			return
+		}
+		permStrs := make([]string, 0, len(perms))
+		for _, p := range perms {
+			permStrs = append(permStrs, string(p))
+		}
+		s.sendJSON(w, http.StatusOK, map[string]any{
+			"name":        name,
+			"permissions": permStrs,
+		})
+
+	case http.MethodPost:
+		var req struct {
+			Action     string `json:"action"` // "grant" or "revoke"
+			Permission string `json:"permission"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			s.sendJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+			return
+		}
+
+		perm := plugin.Permission(req.Permission)
+		var actionErr error
+		if req.Action == "grant" {
+			actionErr = sandbox.GrantPermission(name, perm)
+		} else if req.Action == "revoke" {
+			actionErr = sandbox.RevokePermission(name, perm)
+		} else {
+			s.sendJSON(w, http.StatusBadRequest, map[string]string{"error": "action must be 'grant' or 'revoke'"})
+			return
+		}
+
+		if actionErr != nil {
+			s.sendJSON(w, http.StatusNotFound, map[string]string{"error": actionErr.Error()})
+			return
+		}
+
+		s.sendJSON(w, http.StatusOK, map[string]string{
+			"name":       name,
+			"action":     req.Action,
+			"permission": req.Permission,
+		})
+
+	default:
+		s.sendJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+	}
+}
+
+// getPluginDeps 获取插件系统依赖
+func (s *Server) getPluginDeps() (*plugin.Registry, *plugin.Installer, *plugin.Sandbox, error) {
+	mgr, err := config.NewManager()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	pluginsDir := filepath.Join(mgr.HomeDir(), "plugins")
+	reg := plugin.NewRegistry(pluginsDir)
+	inst := plugin.NewInstaller(reg, pluginsDir)
+	sandbox := plugin.NewDefaultSandbox()
+
+	if err := reg.LoadFromDisk(); err != nil {
+		// 非致命错误，继续
+		fmt.Fprintf(os.Stderr, "⚠️  加载插件警告: %v\n", err)
+	}
+
+	for _, entry := range reg.List() {
+		sandbox.RegisterPlugin(entry.Manifest.Name, entry.Manifest)
+	}
+
+	return reg, inst, sandbox, nil
+}
+
+// extractPathSuffix 从路径中提取后缀
+func extractPathSuffix(path, prefix string) string {
+	if !strings.HasPrefix(path, prefix) {
+		return ""
+	}
+	return strings.TrimPrefix(path, prefix)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -151,6 +151,11 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/api/v1/rag/search", s.handleRAGSearch)
 	mux.HandleFunc("/api/v1/rag/stats", s.handleRAGStats)
 
+	// v0.15.0: Plugin API
+	mux.HandleFunc("/api/v1/plugins", s.handlePlugins)
+	mux.HandleFunc("/api/v1/plugins/search", s.handlePluginSearch)
+	mux.HandleFunc("/api/v1/plugins/install", s.handlePluginInstall)
+
 	// 根路由
 	mux.HandleFunc("/", s.handleRoot)
 

--- a/tasks/QUEUE.md
+++ b/tasks/QUEUE.md
@@ -1,0 +1,65 @@
+# LuckyHarness Development Queue
+
+## Version Progress
+
+| Version | Feature | Status | Notes |
+|---------|---------|--------|-------|
+| v0.1.0 | 基础骨架 | ✅ Done | CLI + Config + SOUL + Provider + Memory + Session + Tool |
+| v0.2.0 | Agent Loop | ✅ Done | SSE streaming + tool call parsing + REPL |
+| v0.3.0 | Provider 路由 | ✅ Done | 降级链 + Anthropic/Ollama/OpenRouter + Token 生命周期 |
+| v0.4.0 | 持久记忆 | ✅ Done | 三层架构 + 衰减 + 摘要 + 提升 |
+| v0.5.0 | 工具系统 | ✅ Done | Skill 插件 + MCP + 子代理委派 + 权限审批 |
+| v0.6.0 | 消息网关 | 🔴 Blocked | 需要 Bot Token (Telegram/Discord/Slack) |
+| v0.7.0 | 定时与自动化 | ✅ Done | Cron 引擎 + 自然语言解析 + Watcher |
+| v0.8.0 | 沙箱与安全 | 🔴 Blocked | 需要 Docker 环境 |
+| v0.9.0 | 多实例 Profile | ✅ Done | Profile 隔离 + Dashboard + Backup + Debug |
+| v0.10.0 | Tool Gateway | ✅ Done | 统一网关 + 路由 + 订阅 + 计量配额 |
+| v0.11.0 | Session & Stream | ✅ Done | 会话持久化 + 流式工具调用 + 配置热重载 |
+| v0.12.0 | API Server | ✅ Done | HTTP RESTful + SSE + 认证限流 |
+| v0.13.0 | Context Window | ✅ Done | Token 估算 + 4 种裁剪策略 + 优先级 |
+| v0.14.0 | RAG 知识库 | ✅ Done | 向量索引 + 语义检索 + 持久化 + API 端点 |
+| v0.15.0 | Plugin Marketplace | 🔴 Ready | 插件注册中心 + 发现 + 安装 + 版本管理 |
+| v0.16.0 | Multi-turn RAG | 🔴 Ready | 对话式检索 + 追问 + 上下文感知检索 |
+
+---
+
+## 🔴 Ready — v0.15.0 Plugin Marketplace
+
+### 子任务
+
+- [ ] **PM-1**: Plugin Manifest 规范 — 定义 plugin.yaml 格式（name, version, author, entry, permissions, dependencies）
+- [ ] **PM-2**: Plugin Registry — 插件注册中心，支持本地 + 远程仓库
+- [ ] **PM-3**: Plugin Installer — 下载/安装/卸载/更新插件
+- [ ] **PM-4**: Plugin Sandbox — 插件运行时隔离（权限控制 + 资源限制）
+- [ ] **PM-5**: Plugin CLI — `lh plugin install/list/update/remove/search`
+- [ ] **PM-6**: Plugin API — `/api/v1/plugins` 端点
+- [ ] **PM-7**: 测试 — 每个子模块单元测试
+
+---
+
+## 🔴 Ready — v0.16.0 Multi-turn RAG
+
+### 子任务
+
+- [ ] **MR-1**: ConversationContext — 跟踪对话历史用于检索优化
+- [ ] **MR-2**: QueryRewriter — 基于上下文重写用户查询
+- [ ] **MR-3**: FollowUpDetector — 检测追问/澄清需求
+- [ ] **MR-4**: ContextAwareRetriever — 结合对话上下文的检索器
+- [ ] **MR-5**: RAG Feedback Loop — 检索结果反馈到对话策略
+- [ ] **MR-6**: 测试 — 每个子模块单元测试
+
+---
+
+## 🔴 Blocked
+
+### v0.6.0 消息网关
+- 需要: Bot Token (Telegram/Discord/Slack)
+- 用户需提供至少一个平台的 Bot Token
+
+### v0.8.0 沙箱与安全
+- 需要: Docker 环境
+- 当前运行环境无 Docker
+
+---
+
+*Last updated: 2026-04-20*


### PR DESCRIPTION
## v0.15.0 — Plugin Marketplace

### 新增
- **plugin.yaml 清单**: name/version/author/description/entry/type/tags/dependencies/permissions/config_schema
- **插件类型**: skill, tool, provider, hook
- **8 种权限**: filesystem, network, memory, tool, rag, session, config, admin
- **Registry**: 注册/注销/查询/列表/按类型过滤/按状态过滤/依赖检查/磁盘加载
- **Installer**: 本地安装/卸载/更新/文件复制
- **Sandbox**: 权限控制 + 资源限制 (256MB/50%CPU/10goroutine/30s/1MB/60rpm) + 频率控制
- **RemoteIndex**: 远程仓库索引 + 搜索
- **CLI**: lh plugin install/list/remove/update/search/info/enable/disable
- **API**: GET /api/v1/plugins, GET /api/v1/plugins/search, POST /api/v1/plugins/install, DELETE /api/v1/plugins/{name}, POST /api/v1/plugins/{name}/enable|disable, GET/POST /api/v1/plugins/{name}/permissions

### 测试
- 37 plugin tests (manifest + manifest_io + registry + installer + sandbox)
- 全量 go test ./... -race 通过

### 文件变更
- 14 files, +3142 / -2 lines