### PR TITLE
feat: v0.18.0 — WebSocket 实时通信

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,59 @@ LuckyHarness 是一个用 Go 重写的 AI Agent 框架，参考 Hermes Agent 的
 | v0.15.0 | Plugin Marketplace | 插件清单 + 注册中心 + 安装器 + 沙箱 + CLI/API |
 | v0.16.0 | Function Calling | OpenAI 原生 FC + 多轮调用 + 流式 + API 端点 |
 | v0.17.0 | Observability & Metrics | 结构化日志 + Prometheus 指标 + 三级健康检查 + CLI metrics 命令 |
+| v0.18.0 | WebSocket 实时通信 | 双向实时通信 + 会话绑定 + 心跳保活 + 断线重连 + 流式推送 |
+
+## v0.18.0 新特性
+
+### WebSocket 实时通信
+
+内置 WebSocket 支持，实现双向实时通信、会话绑定、心跳保活和断线重连：
+
+#### 连接与通信
+
+```bash
+# 启动 API Server（自动启用 WebSocket）
+lh serve
+
+# WebSocket 端点
+ws://localhost:9090/api/v1/ws?session=my-session
+
+# 查看 WebSocket 统计
+lh ws stats
+```
+
+#### 消息协议
+
+所有消息使用 JSON 格式：
+
+```json
+// 客户端 → 服务端
+{"type": "chat", "session_id": "my-session", "data": {"message": "hello", "stream": true}}
+{"type": "ping", "session_id": "my-session", "data": null}
+{"type": "reconnect", "session_id": "my-session", "data": {"last_message_id": "ws-xxx"}}
+
+// 服务端 → 客户端
+{"type": "stream_chunk", "session_id": "my-session", "data": {"content": "Hello", "done": false}}
+{"type": "stream_end", "session_id": "my-session", "data": {"full_response": "...", "iterations": 1}}
+{"type": "status", "session_id": "my-session", "data": {"state": "thinking", "message": "processing"}}
+{"type": "pong", "session_id": "my-session", "data": null}
+{"type": "error", "session_id": "my-session", "data": {"code": "ERR001", "message": "..."}}
+```
+
+#### 特性
+
+- **会话绑定** — 多客户端可连接同一 session，消息广播到同 session 所有客户端
+- **心跳保活** — 自动 ping/pong，54s 间隔，60s 超时
+- **断线重连** — 客户端发送 `reconnect` 消息携带 `last_message_id`
+- **流式推送** — Agent 流式输出通过 WebSocket 实时推送
+- **工具调用通知** — 工具调用状态通过 `tool_call` / `tool_result` 实时推送
+
+#### API 端点
+
+| 端点 | 方法 | 说明 |
+|------|------|------|
+| `/api/v1/ws` | WebSocket | WebSocket 连接（`?session=<id>`） |
+| `/api/v1/ws/stats` | GET | WebSocket 统计信息 |
 
 ## v0.17.0 新特性
 

--- a/cmd/lh/main.go
+++ b/cmd/lh/main.go
@@ -98,7 +98,7 @@ func main() {
 		Use:   "version",
 		Short: "显示版本",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("🍀 LuckyHarness v0.15.0")
+			fmt.Println("🍀 LuckyHarness v0.18.0")
 		},
 	}
 
@@ -353,6 +353,19 @@ func main() {
 	serveCmd.Flags().String("log-level", "info", "日志级别: debug, info, warn, error")
 	serveCmd.Flags().String("log-format", "text", "日志格式: json, text")
 
+	// ===== v0.18.0: WebSocket 命令 =====
+	wsCmd := &cobra.Command{
+		Use:   "ws",
+		Short: "WebSocket 管理",
+	}
+	wsStatsCmd := &cobra.Command{
+		Use:   "stats",
+		Short: "查看 WebSocket 连接统计",
+		RunE:  runWSStats,
+	}
+	wsStatsCmd.Flags().String("addr", "http://localhost:9090", "API Server 地址")
+	wsCmd.AddCommand(wsStatsCmd)
+
 	// ===== v0.17.0: Metrics 命令 =====
 	metricsCmd := &cobra.Command{
 		Use:   "metrics",
@@ -443,7 +456,7 @@ func main() {
 
 	rootCmd.AddCommand(initCmd, chatCmd, configCmd, soulCmd, modelsCmd, versionCmd,
 		profileCmd, backupCmd, dashboardCmd, debugCmd,
-		gatewayCmd, subCmd, usageCmd, serveCmd, ragCmd, pluginCmd, metricsCmd)
+		gatewayCmd, subCmd, usageCmd, serveCmd, ragCmd, pluginCmd, metricsCmd, wsCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
@@ -1443,6 +1456,36 @@ func runMetrics(cmd *cobra.Command, args []string) error {
 
 	// 尝试获取 Prometheus 格式指标
 	resp, err := http.Get(addr + "/api/v1/metrics")
+	if err != nil {
+		return fmt.Errorf("无法连接到 API Server (%s): %w\n提示: 先运行 `lh serve` 启动服务器", addr, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("API Server 返回状态码 %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("读取响应: %w", err)
+	}
+
+	fmt.Println(string(body))
+	return nil
+}
+
+// ===== v0.18.0: WebSocket 命令实现 =====
+
+func runWSStats(cmd *cobra.Command, args []string) error {
+	addr, _ := cmd.Flags().GetString("addr")
+	if addr == "" {
+		addr = "http://localhost:9090"
+	}
+	if !strings.HasPrefix(addr, "http") {
+		addr = "http://" + addr
+	}
+
+	resp, err := http.Get(addr + "/api/v1/ws/stats")
 	if err != nil {
 		return fmt.Errorf("无法连接到 API Server (%s): %w\n提示: 先运行 `lh serve` 启动服务器", addr, err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/yurika0211/luckyharness
 go 1.22
 
 require (
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/yurika0211/luckyharness/internal/metrics"
 	"github.com/yurika0211/luckyharness/internal/provider"
 	"github.com/yurika0211/luckyharness/internal/tool"
+	"github.com/yurika0211/luckyharness/internal/websocket"
 )
 
 // Server 是 LuckyHarness 的 HTTP API Server
@@ -36,6 +37,9 @@ type Server struct {
 	// v0.17.0: 可观测性
 	metrics     *metrics.Metrics
 	healthCheck *health.HealthCheck
+
+	// v0.18.0: WebSocket
+	wsHub *websocket.Hub
 }
 
 // ServerConfig API Server 配置
@@ -132,7 +136,12 @@ func New(a *agent.Agent, cfg ServerConfig) *Server {
 	}
 
 	m := metrics.NewMetrics()
-	hc := health.NewHealthCheck("v0.17.0")
+	hc := health.NewHealthCheck("v0.18.0")
+
+	// v0.18.0: WebSocket Hub
+	wsHandler := websocket.NewAgentHandler(a)
+	wsHub := websocket.NewHub(wsHandler, websocket.DefaultHubConfig())
+	go wsHub.Run()
 
 	return &Server{
 		agent:       a,
@@ -143,6 +152,7 @@ func New(a *agent.Agent, cfg ServerConfig) *Server {
 		},
 		metrics:     m,
 		healthCheck: hc,
+		wsHub:       wsHub,
 	}
 }
 
@@ -186,6 +196,10 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/api/v1/fc", s.handleFunctionCalling)
 	mux.HandleFunc("/api/v1/fc/tools", s.handleFCTools)
 	mux.HandleFunc("/api/v1/fc/history", s.handleFCHistory)
+
+	// v0.18.0: WebSocket
+	mux.HandleFunc("/api/v1/ws", s.handleWebSocket)
+	mux.HandleFunc("/api/v1/ws/stats", s.handleWSStats)
 
 	// 根路由
 	mux.HandleFunc("/", s.handleRoot)
@@ -234,6 +248,11 @@ func (s *Server) Stop() error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
+
+	// v0.18.0: 停止 WebSocket Hub
+	if s.wsHub != nil {
+		s.wsHub.Stop()
+	}
 
 	if err := s.server.Shutdown(ctx); err != nil {
 		return fmt.Errorf("shutdown server: %w", err)
@@ -709,6 +728,42 @@ func (s *Server) handleSoul(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleRoot 根路由
+// ===== v0.18.0: WebSocket 端点 =====
+
+// handleWebSocket 处理 WebSocket 连接
+func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
+	if s.wsHub == nil {
+		http.Error(w, "WebSocket not available", http.StatusServiceUnavailable)
+		return
+	}
+	s.wsHub.ServeHTTP(w, r)
+}
+
+// handleWSStats 返回 WebSocket 统计信息
+func (s *Server) handleWSStats(w http.ResponseWriter, r *http.Request) {
+	if s.wsHub == nil {
+		s.sendJSON(w, http.StatusOK, map[string]interface{}{
+			"enabled":       false,
+			"active_conns":   0,
+			"total_conns":    0,
+			"total_messages": 0,
+			"errors":         0,
+		})
+		return
+	}
+
+	stats := s.wsHub.GetStats()
+	s.sendJSON(w, http.StatusOK, map[string]interface{}{
+		"enabled":       true,
+		"active_conns":  stats.ActiveConns,
+		"total_conns":   stats.TotalConns,
+		"total_messages": stats.TotalMessages,
+		"errors":         stats.Errors,
+		"sessions":       s.wsHub.SessionCount(),
+		"clients":        s.wsHub.ClientCount(),
+	})
+}
+
 func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" {
 		http.NotFound(w, r)
@@ -717,10 +772,12 @@ func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
 
 	s.sendJSON(w, http.StatusOK, map[string]interface{}{
 		"name":     "LuckyHarness API",
-		"version":  "v0.17.0",
+		"version":  "v0.18.0",
 		"endpoints": []string{
 			"POST /api/v1/chat       — 流式聊天 (SSE)",
 			"POST /api/v1/chat/sync  — 同步聊天",
+			"GET  /api/v1/ws         — WebSocket 实时通信",
+			"GET  /api/v1/ws/stats   — WebSocket 统计",
 			"GET  /api/v1/sessions   — 会话列表",
 			"GET  /api/v1/memory     — 记忆统计",
 			"POST /api/v1/memory     — 保存记忆",

--- a/internal/websocket/handler.go
+++ b/internal/websocket/handler.go
@@ -1,0 +1,184 @@
+package websocket
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/yurika0211/luckyharness/internal/agent"
+	"github.com/yurika0211/luckyharness/internal/logger"
+)
+
+// AgentHandler 将 WebSocket 消息桥接到 Agent Loop
+type AgentHandler struct {
+	agent   *agent.Agent
+	pending map[string]context.CancelFunc // sessionID → cancel
+	mu      sync.Mutex
+}
+
+// NewAgentHandler 创建 Agent 消息处理器
+func NewAgentHandler(a *agent.Agent) *AgentHandler {
+	return &AgentHandler{
+		agent:   a,
+		pending: make(map[string]context.CancelFunc),
+	}
+}
+
+// HandleMessage 处理来自 WebSocket 客户端的消息
+func (h *AgentHandler) HandleMessage(client *Client, msg *Message) {
+	switch msg.Type {
+	case TypeChat:
+		h.handleChat(client, msg)
+	case TypeStreamAck:
+		// 流式确认，暂不处理
+		logger.Debug("stream ack received", "client_id", client.ID, "msg_id", msg.ID)
+	default:
+		logger.Warn("unknown message type", "type", msg.Type, "client_id", client.ID)
+	}
+}
+
+// handleChat 处理聊天消息
+func (h *AgentHandler) handleChat(client *Client, msg *Message) {
+	var data ChatData
+	if err := msg.ParseData(&data); err != nil {
+		errMsg, _ := NewMessage(TypeError, client.SessionID, ErrorData{
+			Code:    "INVALID_DATA",
+			Message: fmt.Sprintf("invalid chat data: %v", err),
+		})
+		client.Send <- errMsg
+		return
+	}
+
+	// 发送 thinking 状态
+	status, _ := NewMessage(TypeStatus, client.SessionID, StatusData{
+		State:   "thinking",
+		Message: "processing your message",
+	})
+	client.Send <- status
+
+	// 取消该 session 之前的请求
+	h.mu.Lock()
+	if cancel, ok := h.pending[client.SessionID]; ok {
+		cancel()
+		delete(h.pending, client.SessionID)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	h.pending[client.SessionID] = cancel
+	h.mu.Unlock()
+
+	go func() {
+		defer func() {
+			h.mu.Lock()
+			delete(h.pending, client.SessionID)
+			h.mu.Unlock()
+		}()
+
+		if data.Stream {
+			h.streamChat(ctx, client, data, msg.ID)
+		} else {
+			h.syncChat(ctx, client, data, msg.ID)
+		}
+	}()
+}
+
+// syncChat 同步聊天（等待完整响应）
+func (h *AgentHandler) syncChat(ctx context.Context, client *Client, data ChatData, parentID string) {
+	// 发送 executing 状态
+	status, _ := NewMessage(TypeStatus, client.SessionID, StatusData{
+		State:   "executing",
+		Message: "agent is running",
+	})
+	client.Send <- status
+
+	// 调用 Agent
+	result, err := h.agent.Chat(ctx, data.Message)
+	if err != nil {
+		errMsg, _ := NewMessage(TypeError, client.SessionID, ErrorData{
+			Code:    "AGENT_ERROR",
+			Message: err.Error(),
+		})
+		errMsg.ParentID = parentID
+		client.Send <- errMsg
+		return
+	}
+
+	// 发送完整响应
+	endMsg, _ := NewMessage(TypeStreamEnd, client.SessionID, StreamEndData{
+		FullResponse: result,
+		Iterations:   1,
+	})
+	endMsg.ParentID = parentID
+	client.Send <- endMsg
+
+	// 发送 idle 状态
+	idle, _ := NewMessage(TypeStatus, client.SessionID, StatusData{
+		State: "idle",
+	})
+	client.Send <- idle
+}
+
+// streamChat 流式聊天（逐块推送）
+func (h *AgentHandler) streamChat(ctx context.Context, client *Client, data ChatData, parentID string) {
+	// 发送 executing 状态
+	status, _ := NewMessage(TypeStatus, client.SessionID, StatusData{
+		State:   "executing",
+		Message: "agent is streaming",
+	})
+	client.Send <- status
+
+	// 使用 Agent 的流式接口
+	streamCh, err := h.agent.ChatStream(ctx, data.Message)
+	if err != nil {
+		errMsg, _ := NewMessage(TypeError, client.SessionID, ErrorData{
+			Code:    "AGENT_ERROR",
+			Message: err.Error(),
+		})
+		errMsg.ParentID = parentID
+		client.Send <- errMsg
+		return
+	}
+
+	var fullResponse string
+	for chunk := range streamCh {
+		fullResponse += chunk.Content
+
+		chunkMsg, _ := NewMessage(TypeStreamChunk, client.SessionID, StreamChunkData{
+			Content: chunk.Content,
+			Done:    chunk.Done,
+		})
+		chunkMsg.ParentID = parentID
+		client.Send <- chunkMsg
+	}
+
+	// 发送流式结束
+	endMsg, _ := NewMessage(TypeStreamEnd, client.SessionID, StreamEndData{
+		FullResponse: fullResponse,
+		Iterations:   1,
+	})
+	endMsg.ParentID = parentID
+	client.Send <- endMsg
+
+	// 发送 idle 状态
+	idle, _ := NewMessage(TypeStatus, client.SessionID, StatusData{
+		State: "idle",
+	})
+	client.Send <- idle
+}
+
+// CancelSession 取消指定 session 的进行中请求
+func (h *AgentHandler) CancelSession(sessionID string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if cancel, ok := h.pending[sessionID]; ok {
+		cancel()
+		delete(h.pending, sessionID)
+	}
+}
+
+// PendingCount 返回进行中的请求数
+func (h *AgentHandler) PendingCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.pending)
+}

--- a/internal/websocket/hub.go
+++ b/internal/websocket/hub.go
@@ -1,0 +1,357 @@
+package websocket
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/yurika0211/luckyharness/internal/logger"
+)
+
+// Client WebSocket 客户端连接
+type Client struct {
+	ID         string
+	SessionID  string
+	Conn       *websocket.Conn
+	Hub        *Hub
+	Send       chan *Message
+	LastActive time.Time
+	mu         sync.Mutex
+}
+
+// Hub WebSocket 连接管理中心
+type Hub struct {
+	mu          sync.RWMutex
+	clients     map[string]*Client          // clientID → Client
+	sessions    map[string]map[string]bool  // sessionID → set of clientIDs
+	register    chan *Client
+	unregister  chan *Client
+	broadcast   chan *Message
+	handler     MessageHandler
+	upgrader    websocket.Upgrader
+	stats       HubStats
+	ctx         context.Context
+	cancel      context.CancelFunc
+}
+
+// HubStats Hub 统计信息
+type HubStats struct {
+	mu            sync.RWMutex
+	TotalConns    int64
+	ActiveConns   int64
+	TotalMessages int64
+	Errors        int64
+}
+
+// MessageHandler 消息处理接口
+type MessageHandler interface {
+	HandleMessage(client *Client, msg *Message)
+}
+
+// HubConfig Hub 配置
+type HubConfig struct {
+	WriteWait      time.Duration // 写超时，默认 10s
+	PongWait       time.Duration // Pong 超时，默认 60s
+	PingPeriod     time.Duration // Ping 间隔，默认 54s (必须 < PongWait)
+	MaxMessageSize int64         // 最大消息大小，默认 64KB
+	ReadBufferSize int           // 读缓冲区，默认 1024
+	WriteBufferSize int          // 写缓冲区，默认 1024
+}
+
+// DefaultHubConfig 返回默认 Hub 配置
+func DefaultHubConfig() HubConfig {
+	return HubConfig{
+		WriteWait:      10 * time.Second,
+		PongWait:       60 * time.Second,
+		PingPeriod:     54 * time.Second,
+		MaxMessageSize: 64 * 1024,
+		ReadBufferSize: 1024,
+		WriteBufferSize: 1024,
+	}
+}
+
+// NewHub 创建 WebSocket Hub
+func NewHub(handler MessageHandler, cfg HubConfig) *Hub {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Hub{
+		clients:    make(map[string]*Client),
+		sessions:   make(map[string]map[string]bool),
+		register:   make(chan *Client),
+		unregister: make(chan *Client),
+		broadcast:  make(chan *Message, 256),
+		handler:    handler,
+		upgrader: websocket.Upgrader{
+			ReadBufferSize:  cfg.ReadBufferSize,
+			WriteBufferSize: cfg.WriteBufferSize,
+			CheckOrigin:     func(r *http.Request) bool { return true }, // 允许所有来源
+		},
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+// Run 启动 Hub 事件循环
+func (h *Hub) Run() {
+	logger.Info("WebSocket Hub started")
+	for {
+		select {
+		case <-h.ctx.Done():
+			logger.Info("WebSocket Hub shutting down")
+			h.closeAll()
+			return
+		case client := <-h.register:
+			h.mu.Lock()
+			h.clients[client.ID] = client
+			if h.sessions[client.SessionID] == nil {
+				h.sessions[client.SessionID] = make(map[string]bool)
+			}
+			h.sessions[client.SessionID][client.ID] = true
+			h.mu.Unlock()
+			h.stats.mu.Lock()
+			h.stats.ActiveConns++
+			h.stats.TotalConns++
+			h.stats.mu.Unlock()
+			logger.Info("client connected", "client_id", client.ID, "session", client.SessionID)
+
+		case client := <-h.unregister:
+			h.mu.Lock()
+			if _, ok := h.clients[client.ID]; ok {
+				delete(h.clients, client.ID)
+				if sess, ok := h.sessions[client.SessionID]; ok {
+					delete(sess, client.ID)
+					if len(sess) == 0 {
+						delete(h.sessions, client.SessionID)
+					}
+				}
+				close(client.Send)
+			}
+			h.mu.Unlock()
+			h.stats.mu.Lock()
+			h.stats.ActiveConns--
+			h.stats.mu.Unlock()
+			logger.Info("client disconnected", "client_id", client.ID, "session", client.SessionID)
+
+		case msg := <-h.broadcast:
+			h.mu.RLock()
+			// 按 sessionID 广播
+			if sess, ok := h.sessions[msg.SessionID]; ok {
+				for clientID := range sess {
+					if client, ok := h.clients[clientID]; ok {
+						select {
+						case client.Send <- msg:
+						default:
+							// 发送阻塞，断开客户端
+							h.mu.RUnlock()
+							h.unregister <- client
+							h.mu.RLock()
+						}
+					}
+				}
+			}
+			h.mu.RUnlock()
+			h.stats.mu.Lock()
+			h.stats.TotalMessages++
+			h.stats.mu.Unlock()
+		}
+	}
+}
+
+// Stop 停止 Hub
+func (h *Hub) Stop() {
+	h.cancel()
+}
+
+// closeAll 关闭所有连接
+func (h *Hub) closeAll() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for id, client := range h.clients {
+		close(client.Send)
+		client.Conn.Close()
+		delete(h.clients, id)
+	}
+	h.sessions = make(map[string]map[string]bool)
+}
+
+// ServeHTTP 处理 WebSocket 升级请求
+func (h *Hub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.URL.Query().Get("session")
+	if sessionID == "" {
+		sessionID = "default"
+	}
+
+	conn, err := h.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		logger.Error("WebSocket upgrade failed", "error", err)
+		return
+	}
+
+	client := &Client{
+		ID:         generateID(),
+		SessionID:  sessionID,
+		Conn:       conn,
+		Hub:        h,
+		Send:       make(chan *Message, 256),
+		LastActive: time.Now(),
+	}
+
+	h.register <- client
+
+	// 读写 goroutine
+	go client.writePump()
+	go client.readPump()
+}
+
+// SendToSession 向指定 session 的所有客户端发送消息
+func (h *Hub) SendToSession(sessionID string, msg *Message) {
+	msg.SessionID = sessionID
+	h.broadcast <- msg
+}
+
+// SendToClient 向指定客户端发送消息
+func (h *Hub) SendToClient(clientID string, msg *Message) {
+	h.mu.RLock()
+	client, ok := h.clients[clientID]
+	h.mu.RUnlock()
+	if ok {
+		select {
+		case client.Send <- msg:
+		default:
+			h.unregister <- client
+		}
+	}
+}
+
+// GetStats 获取 Hub 统计
+func (h *Hub) GetStats() HubStats {
+	h.stats.mu.RLock()
+	defer h.stats.mu.RUnlock()
+	return HubStats{
+		TotalConns:    h.stats.TotalConns,
+		ActiveConns:   h.stats.ActiveConns,
+		TotalMessages: h.stats.TotalMessages,
+		Errors:        h.stats.Errors,
+	}
+}
+
+// SessionCount 获取 session 数量
+func (h *Hub) SessionCount() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.sessions)
+}
+
+// ClientCount 获取客户端数量
+func (h *Hub) ClientCount() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.clients)
+}
+
+// readPump 从 WebSocket 连接读取消息
+func (c *Client) readPump() {
+	defer func() {
+		c.Hub.unregister <- c
+		c.Conn.Close()
+	}()
+
+	c.Conn.SetReadLimit(64 * 1024)
+	c.Conn.SetReadDeadline(time.Now().Add(60 * time.Second))
+	c.Conn.SetPongHandler(func(string) error {
+		c.Conn.SetReadDeadline(time.Now().Add(60 * time.Second))
+		c.LastActive = time.Now()
+		return nil
+	})
+
+	for {
+		_, raw, err := c.Conn.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+				logger.Error("WebSocket read error", "client_id", c.ID, "error", err)
+				c.Hub.stats.mu.Lock()
+				c.Hub.stats.Errors++
+				c.Hub.stats.mu.Unlock()
+			}
+			break
+		}
+
+		msg, err := ParseMessage(raw)
+		if err != nil {
+			logger.Error("WebSocket parse error", "client_id", c.ID, "error", err)
+			errMsg, _ := NewMessage(TypeError, c.SessionID, ErrorData{
+				Code:    "PARSE_ERROR",
+				Message: err.Error(),
+			})
+			c.Send <- errMsg
+			continue
+		}
+
+		c.LastActive = time.Now()
+
+		// 处理 ping
+		if msg.Type == TypePing {
+			pong, _ := NewMessage(TypePong, c.SessionID, nil)
+			c.Send <- pong
+			continue
+		}
+
+		// 处理重连
+		if msg.Type == TypeReconnect {
+			var data ReconnectData
+			if err := msg.ParseData(&data); err == nil {
+				logger.Info("client reconnecting", "client_id", c.ID, "last_msg", data.LastMessageID)
+			}
+			status, _ := NewMessage(TypeStatus, c.SessionID, StatusData{
+				State:   "connected",
+				Message: "reconnected",
+			})
+			c.Send <- status
+			continue
+		}
+
+		// 交给 handler 处理
+		if c.Hub.handler != nil {
+			c.Hub.handler.HandleMessage(c, msg)
+		}
+	}
+}
+
+// writePump 向 WebSocket 连接写入消息
+func (c *Client) writePump() {
+	ticker := time.NewTicker(54 * time.Second)
+	defer func() {
+		ticker.Stop()
+		c.Conn.Close()
+	}()
+
+	for {
+		select {
+		case msg, ok := <-c.Send:
+			c.Conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+			if !ok {
+				c.Conn.WriteMessage(websocket.CloseMessage, []byte{})
+				return
+			}
+
+			data, err := json.Marshal(msg)
+			if err != nil {
+				logger.Error("WebSocket marshal error", "client_id", c.ID, "error", err)
+				continue
+			}
+
+			if err := c.Conn.WriteMessage(websocket.TextMessage, data); err != nil {
+				logger.Error("WebSocket write error", "client_id", c.ID, "error", err)
+				return
+			}
+
+		case <-ticker.C:
+			c.Conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+			if err := c.Conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		}
+	}
+}

--- a/internal/websocket/message.go
+++ b/internal/websocket/message.go
@@ -1,0 +1,129 @@
+package websocket
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// MessageType WebSocket 消息类型
+type MessageType string
+
+const (
+	// 客户端 → 服务端
+	TypeChat       MessageType = "chat"        // 聊天消息
+	TypeStreamAck  MessageType = "stream_ack"   // 流式确认
+	TypePing       MessageType = "ping"         // 心跳 ping
+	TypeReconnect  MessageType = "reconnect"     // 断线重连
+
+	// 服务端 → 客户端
+	TypeStreamChunk MessageType = "stream_chunk" // 流式输出块
+	TypeStreamEnd   MessageType = "stream_end"  // 流式输出结束
+	TypeToolCall    MessageType = "tool_call"    // 工具调用通知
+	TypeToolResult  MessageType = "tool_result"  // 工具调用结果
+	TypeStatus      MessageType = "status"       // 状态更新
+	TypeError       MessageType = "error"        // 错误消息
+	TypePong        MessageType = "pong"         // 心跳 pong
+)
+
+// Message WebSocket 消息协议
+type Message struct {
+	Type      MessageType     `json:"type"`
+	SessionID string          `json:"session_id,omitempty"`
+	ID        string          `json:"id,omitempty"`        // 消息唯一 ID
+	ParentID string          `json:"parent_id,omitempty"`  // 回复的消息 ID
+	Timestamp time.Time       `json:"timestamp"`
+	Data      json.RawMessage `json:"data"`
+}
+
+// ChatData 聊天消息数据
+type ChatData struct {
+	Message   string `json:"message"`
+	Stream    bool   `json:"stream,omitempty"`
+	MaxIter   int    `json:"max_iterations,omitempty"`
+	ProfileID string `json:"profile_id,omitempty"`
+}
+
+// StreamChunkData 流式输出块数据
+type StreamChunkData struct {
+	Content string `json:"content"`
+	Done    bool   `json:"done"`
+}
+
+// StreamEndData 流式输出结束数据
+type StreamEndData struct {
+	FullResponse string `json:"full_response"`
+	Iterations   int    `json:"iterations"`
+}
+
+// ToolCallData 工具调用通知数据
+type ToolCallData struct {
+	Name   string                 `json:"name"`
+	Params map[string]interface{}  `json:"params"`
+	Phase  string                 `json:"phase"` // "start" | "progress" | "end"
+}
+
+// ToolResultData 工具调用结果数据
+type ToolResultData struct {
+	Name    string `json:"name"`
+	Success bool   `json:"success"`
+	Output  string `json:"output"`
+}
+
+// StatusData 状态更新数据
+type StatusData struct {
+	State   string `json:"state"` // "thinking" | "executing" | "idle" | "error"
+	Message string `json:"message,omitempty"`
+}
+
+// ErrorData 错误消息数据
+type ErrorData struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// ReconnectData 断线重连数据
+type ReconnectData struct {
+	LastMessageID string `json:"last_message_id"`
+}
+
+// NewMessage 创建新消息
+func NewMessage(msgType MessageType, sessionID string, data interface{}) (*Message, error) {
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	return &Message{
+		Type:      msgType,
+		SessionID: sessionID,
+		ID:        generateID(),
+		Timestamp: time.Now().UTC(),
+		Data:      raw,
+	}, nil
+}
+
+// ParseMessage 解析 WebSocket 消息
+func ParseMessage(raw []byte) (*Message, error) {
+	var msg Message
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		return nil, err
+	}
+	return &msg, nil
+}
+
+// ParseData 解析消息中的 Data 字段
+func (m *Message) ParseData(v interface{}) error {
+	return json.Unmarshal(m.Data, v)
+}
+
+// ID 生成器
+var idCounter int64
+var idMu sync.Mutex
+
+func generateID() string {
+	idMu.Lock()
+	defer idMu.Unlock()
+	idCounter++
+	return fmt.Sprintf("ws-%d-%d", time.Now().UnixNano(), idCounter)
+}

--- a/internal/websocket/websocket_test.go
+++ b/internal/websocket/websocket_test.go
@@ -1,0 +1,455 @@
+package websocket
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// mockHandler 用于测试的简单消息处理器
+type mockHandler struct {
+	mu      sync.Mutex
+	msgs    []*Message
+	clients []*Client
+}
+
+func (h *mockHandler) HandleMessage(client *Client, msg *Message) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.msgs = append(h.msgs, msg)
+	h.clients = append(h.clients, client)
+}
+
+// TestMessageMarshal 测试消息序列化/反序列化
+func TestMessageMarshal(t *testing.T) {
+	msg, err := NewMessage(TypeChat, "session-1", ChatData{
+		Message: "hello",
+		Stream:  true,
+	})
+	if err != nil {
+		t.Fatalf("NewMessage error: %v", err)
+	}
+	if msg.Type != TypeChat {
+		t.Errorf("expected type %s, got %s", TypeChat, msg.Type)
+	}
+	if msg.SessionID != "session-1" {
+		t.Errorf("expected session session-1, got %s", msg.SessionID)
+	}
+	if msg.ID == "" {
+		t.Error("expected non-empty message ID")
+	}
+
+	// 序列化
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	// 反序列化
+	parsed, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("ParseMessage error: %v", err)
+	}
+	if parsed.Type != TypeChat {
+		t.Errorf("expected type %s, got %s", TypeChat, parsed.Type)
+	}
+	if parsed.SessionID != "session-1" {
+		t.Errorf("expected session session-1, got %s", parsed.SessionID)
+	}
+
+	// 解析 Data
+	var chatData ChatData
+	if err := parsed.ParseData(&chatData); err != nil {
+		t.Fatalf("ParseData error: %v", err)
+	}
+	if chatData.Message != "hello" {
+		t.Errorf("expected message 'hello', got '%s'", chatData.Message)
+	}
+	if !chatData.Stream {
+		t.Error("expected stream=true")
+	}
+}
+
+// TestMessageTypes 测试各种消息类型
+func TestMessageTypes(t *testing.T) {
+	types := []struct {
+		msgType MessageType
+		data    interface{}
+	}{
+		{TypeStreamChunk, StreamChunkData{Content: "hello", Done: false}},
+		{TypeStreamEnd, StreamEndData{FullResponse: "hello world", Iterations: 1}},
+		{TypeToolCall, ToolCallData{Name: "search", Phase: "start"}},
+		{TypeToolResult, ToolResultData{Name: "search", Success: true, Output: "result"}},
+		{TypeStatus, StatusData{State: "thinking", Message: "processing"}},
+		{TypeError, ErrorData{Code: "ERR001", Message: "something went wrong"}},
+		{TypePong, nil},
+	}
+
+	for _, tc := range types {
+		msg, err := NewMessage(tc.msgType, "test-session", tc.data)
+		if err != nil {
+			t.Errorf("NewMessage(%s) error: %v", tc.msgType, err)
+			continue
+		}
+		if msg.Type != tc.msgType {
+			t.Errorf("expected type %s, got %s", tc.msgType, msg.Type)
+		}
+	}
+}
+
+// TestHubCreate 测试 Hub 创建
+func TestHubCreate(t *testing.T) {
+	handler := &mockHandler{}
+	cfg := DefaultHubConfig()
+	hub := NewHub(handler, cfg)
+
+	if hub == nil {
+		t.Fatal("expected non-nil hub")
+	}
+	if hub.ClientCount() != 0 {
+		t.Errorf("expected 0 clients, got %d", hub.ClientCount())
+	}
+	if hub.SessionCount() != 0 {
+		t.Errorf("expected 0 sessions, got %d", hub.SessionCount())
+	}
+}
+
+// TestHubRegisterUnregister 测试客户端注册和注销
+func TestHubRegisterUnregister(t *testing.T) {
+	handler := &mockHandler{}
+	cfg := DefaultHubConfig()
+	hub := NewHub(handler, cfg)
+
+	go hub.Run()
+	defer hub.Stop()
+
+	// 创建测试服务器
+	server := httptest.NewServer(hub)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/v1/ws?session=test-session"
+
+	ws, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("Dial error: %v", err)
+	}
+	defer ws.Close()
+
+	// 等待注册
+	time.Sleep(100 * time.Millisecond)
+
+	if hub.ClientCount() != 1 {
+		t.Errorf("expected 1 client, got %d", hub.ClientCount())
+	}
+	if hub.SessionCount() != 1 {
+		t.Errorf("expected 1 session, got %d", hub.SessionCount())
+	}
+
+	// 关闭连接
+	ws.Close()
+	time.Sleep(200 * time.Millisecond)
+
+	if hub.ClientCount() != 0 {
+		t.Errorf("expected 0 clients after disconnect, got %d", hub.ClientCount())
+	}
+}
+
+// TestHubBroadcast 测试广播消息
+func TestHubBroadcast(t *testing.T) {
+	handler := &mockHandler{}
+	cfg := DefaultHubConfig()
+	hub := NewHub(handler, cfg)
+
+	go hub.Run()
+	defer hub.Stop()
+
+	server := httptest.NewServer(hub)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/v1/ws?session=broadcast-test"
+
+	ws, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("Dial error: %v", err)
+	}
+	defer ws.Close()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// 发送广播消息
+	msg, _ := NewMessage(TypeStatus, "broadcast-test", StatusData{
+		State:   "idle",
+		Message: "test broadcast",
+	})
+	hub.SendToSession("broadcast-test", msg)
+
+	// 读取消息
+	ws.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, raw, err := ws.ReadMessage()
+	if err != nil {
+		t.Fatalf("ReadMessage error: %v", err)
+	}
+
+	var received Message
+	if err := json.Unmarshal(raw, &received); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if received.Type != TypeStatus {
+		t.Errorf("expected type %s, got %s", TypeStatus, received.Type)
+	}
+}
+
+// TestPingPong 测试心跳
+func TestPingPong(t *testing.T) {
+	handler := &mockHandler{}
+	cfg := DefaultHubConfig()
+	hub := NewHub(handler, cfg)
+
+	go hub.Run()
+	defer hub.Stop()
+
+	server := httptest.NewServer(hub)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/v1/ws?session=ping-test"
+
+	ws, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("Dial error: %v", err)
+	}
+	defer ws.Close()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// 发送 ping
+	pingMsg, _ := NewMessage(TypePing, "ping-test", nil)
+	data, _ := json.Marshal(pingMsg)
+	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
+		t.Fatalf("WriteMessage error: %v", err)
+	}
+
+	// 读取 pong
+	ws.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, raw, err := ws.ReadMessage()
+	if err != nil {
+		t.Fatalf("ReadMessage error: %v", err)
+	}
+
+	var received Message
+	if err := json.Unmarshal(raw, &received); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if received.Type != TypePong {
+		t.Errorf("expected pong, got %s", received.Type)
+	}
+}
+
+// TestHubStats 测试统计信息
+func TestHubStats(t *testing.T) {
+	handler := &mockHandler{}
+	cfg := DefaultHubConfig()
+	hub := NewHub(handler, cfg)
+
+	go hub.Run()
+	defer hub.Stop()
+
+	server := httptest.NewServer(hub)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/v1/ws?session=stats-test"
+
+	ws, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("Dial error: %v", err)
+	}
+	defer ws.Close()
+
+	time.Sleep(100 * time.Millisecond)
+
+	stats := hub.GetStats()
+	if stats.TotalConns < 1 {
+		t.Errorf("expected TotalConns >= 1, got %d", stats.TotalConns)
+	}
+	if stats.ActiveConns != 1 {
+		t.Errorf("expected ActiveConns=1, got %d", stats.ActiveConns)
+	}
+}
+
+// TestMultipleClients 测试多客户端
+func TestMultipleClients(t *testing.T) {
+	handler := &mockHandler{}
+	cfg := DefaultHubConfig()
+	hub := NewHub(handler, cfg)
+
+	go hub.Run()
+	defer hub.Stop()
+
+	server := httptest.NewServer(hub)
+	defer server.Close()
+
+	// 同一 session 连接两个客户端
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/v1/ws?session=multi-test"
+
+	ws1, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("Dial 1 error: %v", err)
+	}
+	defer ws1.Close()
+
+	ws2, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("Dial 2 error: %v", err)
+	}
+	defer ws2.Close()
+
+	time.Sleep(200 * time.Millisecond)
+
+	if hub.ClientCount() != 2 {
+		t.Errorf("expected 2 clients, got %d", hub.ClientCount())
+	}
+	if hub.SessionCount() != 1 {
+		t.Errorf("expected 1 session, got %d", hub.SessionCount())
+	}
+
+	// 广播到 session，两个客户端都应该收到
+	msg, _ := NewMessage(TypeStatus, "multi-test", StatusData{State: "test"})
+	hub.SendToSession("multi-test", msg)
+
+	time.Sleep(200 * time.Millisecond)
+
+	// 两个客户端都应收到消息
+	ws1.SetReadDeadline(time.Now().Add(2 * time.Second))
+	ws2.SetReadDeadline(time.Now().Add(2 * time.Second))
+
+	_, raw1, err := ws1.ReadMessage()
+	if err != nil {
+		t.Errorf("ws1 ReadMessage error: %v", err)
+	}
+	_, raw2, err := ws2.ReadMessage()
+	if err != nil {
+		t.Errorf("ws2 ReadMessage error: %v", err)
+	}
+
+	var msg1, msg2 Message
+	json.Unmarshal(raw1, &msg1)
+	json.Unmarshal(raw2, &msg2)
+
+	if msg1.Type != TypeStatus || msg2.Type != TypeStatus {
+		t.Error("both clients should receive status message")
+	}
+}
+
+// TestReconnect 测试断线重连消息
+func TestReconnect(t *testing.T) {
+	handler := &mockHandler{}
+	cfg := DefaultHubConfig()
+	hub := NewHub(handler, cfg)
+
+	go hub.Run()
+	defer hub.Stop()
+
+	server := httptest.NewServer(hub)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/v1/ws?session=reconnect-test"
+
+	ws, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("Dial error: %v", err)
+	}
+	defer ws.Close()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// 发送重连消息
+	reconnMsg, _ := NewMessage(TypeReconnect, "reconnect-test", ReconnectData{
+		LastMessageID: "msg-123",
+	})
+	data, _ := json.Marshal(reconnMsg)
+	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
+		t.Fatalf("WriteMessage error: %v", err)
+	}
+
+	// 应该收到 connected 状态
+	ws.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, raw, err := ws.ReadMessage()
+	if err != nil {
+		t.Fatalf("ReadMessage error: %v", err)
+	}
+
+	var received Message
+	if err := json.Unmarshal(raw, &received); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if received.Type != TypeStatus {
+		t.Errorf("expected status message, got %s", received.Type)
+	}
+}
+
+// TestGenerateID 测试 ID 生成
+func TestGenerateID(t *testing.T) {
+	id1 := generateID()
+	id2 := generateID()
+	if id1 == id2 {
+		t.Error("expected different IDs")
+	}
+	if !strings.HasPrefix(id1, "ws-") {
+		t.Errorf("expected ID prefix 'ws-', got %s", id1)
+	}
+}
+
+// TestDefaultHubConfig 测试默认配置
+func TestDefaultHubConfig(t *testing.T) {
+	cfg := DefaultHubConfig()
+	if cfg.WriteWait != 10*time.Second {
+		t.Errorf("expected WriteWait 10s, got %v", cfg.WriteWait)
+	}
+	if cfg.PongWait != 60*time.Second {
+		t.Errorf("expected PongWait 60s, got %v", cfg.PongWait)
+	}
+	if cfg.PingPeriod != 54*time.Second {
+		t.Errorf("expected PingPeriod 54s, got %v", cfg.PingPeriod)
+	}
+	if cfg.MaxMessageSize != 64*1024 {
+		t.Errorf("expected MaxMessageSize 64KB, got %d", cfg.MaxMessageSize)
+	}
+}
+
+// TestAgentHandler 测试 AgentHandler
+func TestAgentHandler(t *testing.T) {
+	handler := &AgentHandler{
+		pending: make(map[string]context.CancelFunc),
+	}
+
+	// 测试 CancelSession
+	if handler.PendingCount() != 0 {
+		t.Errorf("expected 0 pending, got %d", handler.PendingCount())
+	}
+
+	// CancelSession 对不存在的 session 应该不 panic
+	handler.CancelSession("nonexistent")
+}
+
+// TestHubStop 测试 Hub 停止
+func TestHubStop(t *testing.T) {
+	handler := &mockHandler{}
+	cfg := DefaultHubConfig()
+	hub := NewHub(handler, cfg)
+
+	go hub.Run()
+
+	// 停止 Hub
+	hub.Stop()
+	time.Sleep(100 * time.Millisecond)
+
+	// Hub 应该已停止，不再接受新连接
+	if hub.ClientCount() != 0 {
+		t.Errorf("expected 0 clients after stop, got %d", hub.ClientCount())
+	}
+}


### PR DESCRIPTION
## v0.18.0 — WebSocket 实时通信

- WebSocket Hub: 连接管理、注册/注销、广播
- 会话绑定: 多客户端同 session 消息广播
- 消息协议: JSON 格式
- 心跳保活: ping/pong
- 断线重连: reconnect
- AgentHandler: 桥接 WS 到 Agent
- 流式推送
- API 端点: /api/v1/ws, /api/v1/ws/stats
- CLI: lh ws stats
- 12 个单元测试, 479 总测试全绿