### PR TITLE
feat: v0.21.0 — 嵌入模型管理系统

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,43 @@ LuckyHarness 是一个用 Go 重写的 AI Agent 框架，参考 Hermes Agent 的
 | v0.18.0 | WebSocket 实时通信 | 双向实时通信 + 会话绑定 + 心跳保活 + 断线重连 + 流式推送 |
 | v0.19.0 | 多语言 SOUL 模板 | TemplateManager + 6 内置模板 + 变量插值 + 语言检测 + API + CLI |
 | v0.20.0 | RAG SQLite 持久化 | SQLite 向量存储 + WAL 模式 + 增量索引 + 持久化 API + REPL 命令 |
+| v0.21.0 | 嵌入模型管理 | Embedder 接口 + Registry + LRU 缓存 + OpenAI/Ollama Provider + API + REPL |
+
+## v0.21.0 新特性
+
+### 嵌入模型管理系统
+
+统一的嵌入模型管理，支持多 Provider 注册、切换和缓存：
+
+```bash
+# 列出嵌入模型
+/embedder
+
+# 切换嵌入模型
+/embedder switch openai-default
+
+# 测试嵌入
+/embedder test "Hello, world!"
+```
+
+#### 特性
+
+- **Embedder 接口** — 统一的 Embed/EmbedBatch/Dimension/Name/Model 接口
+- **Embedder Registry** — 注册、切换、列表管理多个嵌入模型
+- **LRU 缓存** — 相同输入自动缓存向量结果，避免重复 API 调用
+- **OpenAI Provider** — 支持 text-embedding-3-small/large, ada-002 及兼容端点
+- **Ollama Provider** — 支持 nomic-embed-text, mxbai-embed-large 等本地模型
+- **RAG 集成** — RAG 管理器使用 Embedder Registry 的 active embedder（带缓存）
+
+#### API 端点
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET  | `/api/v1/embedders` | 列出所有嵌入模型 |
+| GET  | `/api/v1/embedders/{id}` | 获取嵌入模型详情 |
+| POST | `/api/v1/embedders/register` | 注册新嵌入模型 |
+| POST | `/api/v1/embedders/switch` | 切换活跃嵌入模型 |
+| POST | `/api/v1/embedders/{id}/test` | 测试嵌入模型 |
 
 ## v0.20.0 新特性
 
@@ -404,7 +441,8 @@ permissions:
 - **智能分块**：按段落/句子分割，支持重叠窗口
 - **MMR 重排**：Maximal Marginal Relevance 多样性重排
 - **持久化**：JSON 序列化，启动自动加载，关闭自动保存
-- **可扩展 Embedder**：MockEmbedder（测试）/ OpenAI Embedder（生产）
+- **可扩展 Embedder**：MockEmbedder（测试）/ OpenAI Embedder（生产）/ Ollama Embedder（本地）
+- **Embedder Registry**：多模型注册、切换、LRU 缓存（v0.21.0）
 - **自动上下文注入**：对话时自动检索相关知识注入 system prompt
 
 ## v0.13.0 新特性

--- a/cmd/lh/chat_repl.go
+++ b/cmd/lh/chat_repl.go
@@ -188,6 +188,9 @@ fmt.Println("  /rag index <path>  索引文件/目录到知识库")
 		fmt.Println("  /fc tools          列出 Function Calling 工具")
 		fmt.Println("  /fc history        查看调用历史")
 		fmt.Println("  /fc clear          清除调用历史")
+		fmt.Println("  /embedder          列出嵌入模型")
+		fmt.Println("  /embedder switch <id>  切换嵌入模型")
+		fmt.Println("  /embedder test [text]  测试嵌入模型")
 		fmt.Println("  /clear             清屏")
 		return true, false
 
@@ -430,6 +433,9 @@ fmt.Println("  /rag index <path>  索引文件/目录到知识库")
 
 	case "/fc":
 		return handleFCCommand(arg, a), false
+
+	case "/embedder":
+		return handleEmbedderCommand(arg, a), false
 
 	default:
 		fmt.Printf("未知命令: %s (输入 /help 查看帮助)\n", cmd)
@@ -1160,6 +1166,78 @@ func handleFCCommand(arg string, a *agent.Agent) bool {
 	default:
 		fmt.Printf("未知 fc 子命令: %s\n", parts[0])
 		fmt.Println("用法: /fc <tools|history|clear>")
+	}
+	return true
+}
+
+// ===== v0.21.0: Embedder 命令 =====
+
+func handleEmbedderCommand(arg string, a *agent.Agent) bool {
+	reg := a.EmbedderRegistry()
+	if reg == nil {
+		fmt.Println("❌ 嵌入模型注册表不可用")
+		return true
+	}
+
+	parts := strings.SplitN(arg, " ", 2)
+	subcmd := parts[0]
+	subarg := ""
+	if len(parts) > 1 {
+		subarg = parts[1]
+	}
+
+	switch subcmd {
+	case "", "list":
+		list := reg.List()
+		if len(list) == 0 {
+			fmt.Println("📋 暂无嵌入模型")
+			return true
+		}
+		fmt.Println("📋 嵌入模型:")
+		for _, info := range list {
+			active := ""
+			if info.Active {
+				active = " ← active"
+			}
+			fmt.Printf("  %-20s %-10s %-30s dim=%d%s\n",
+				info.ID, info.Name, info.Model, info.Dimension, active)
+		}
+
+	case "switch":
+		if subarg == "" {
+			fmt.Println("用法: /embedder switch <id>")
+			return true
+		}
+		if !reg.Switch(subarg) {
+			fmt.Printf("❌ 嵌入模型未找到: %s\n", subarg)
+			return true
+		}
+		e := reg.Active()
+		fmt.Printf("✅ 已切换到: %s (%s/%s, dim=%d)\n",
+			subarg, e.Name(), e.Model(), e.Dimension())
+
+	case "test":
+		text := subarg
+		if text == "" {
+			text = "Hello, world!"
+		}
+		e := reg.Active()
+		vec, err := e.Embed(context.Background(), text)
+		if err != nil {
+			fmt.Printf("❌ 嵌入失败: %v\n", err)
+			return true
+		}
+		sampleLen := 5
+		if len(vec) < sampleLen {
+			sampleLen = len(vec)
+		}
+		fmt.Printf("🧮 嵌入测试 (%s/%s, dim=%d):\n", e.Name(), e.Model(), len(vec))
+		fmt.Printf("  输入: %q\n", text)
+		fmt.Printf("  向量前%d维: %v\n", sampleLen, vec[:sampleLen])
+
+	default:
+		fmt.Printf("未知 embedder 子命令: %s\n", subcmd)
+		fmt.Println("用法: /embedder <list|switch|test>")
 	}
 	return true
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/yurika0211/luckyharness/internal/config"
 	"github.com/yurika0211/luckyharness/internal/contextx"
+	"github.com/yurika0211/luckyharness/internal/embedder"
 	"github.com/yurika0211/luckyharness/internal/memory"
 	"github.com/yurika0211/luckyharness/internal/provider"
 	"github.com/yurika0211/luckyharness/internal/rag"
@@ -34,6 +35,7 @@ type Agent struct {
 	contextWin   *contextx.ContextWindow // 上下文窗口管理器
 	ragManager   *rag.RAGManager         // RAG 知识库管理器
 	ragPersist   *rag.Persistence        // RAG 持久化
+	embedderReg  *embedder.Registry      // v0.21.0: 嵌入模型注册表
 	chatCount    int // 对话计数，用于触发自动摘要
 }
 
@@ -152,8 +154,23 @@ func New(cfg *config.Manager) (*Agent, error) {
 	})
 
 	// 创建 RAG 知识库管理器
-	// v0.20.0: 支持 SQLite 持久化后端
-	ragEmbedder := rag.NewMockEmbedder(128) // v0.14.0: 默认 mock, 后续支持配置 OpenAI
+	// v0.21.0: 使用 Embedder Registry 管理嵌入模型
+	embedderReg := embedder.NewRegistry()
+	mockEmb := embedder.NewMockEmbedder(128)
+	embedderReg.Register("mock-128", mockEmb)
+
+	// 注册 OpenAI embedder (如果配置了 API key)
+	if c.APIKey != "" {
+		openaiEmb := embedder.NewOpenAIEmbedder(embedder.OpenAIEmbedderConfig{
+			APIKey:  c.APIKey,
+			BaseURL: c.APIBase,
+		})
+		embedderReg.Register("openai-default", openaiEmb)
+	}
+
+	// 使用 active embedder (带缓存)
+	activeEmb := embedder.NewCachedEmbedder(embedderReg.Active(), 512)
+
 	ragConfig := rag.DefaultRAGConfig()
 
 	var ragManager *rag.RAGManager
@@ -161,10 +178,10 @@ func New(cfg *config.Manager) (*Agent, error) {
 
 	// 尝试使用 SQLite 后端
 	ragDBPath := cfg.HomeDir() + "/rag/luckyharness.db"
-	ragMgr, err := rag.NewRAGManagerWithSQLite(ragEmbedder, ragConfig, ragDBPath)
+	ragMgr, err := rag.NewRAGManagerWithSQLite(activeEmb, ragConfig, ragDBPath)
 	if err != nil {
 		// SQLite 不可用时降级到内存 + JSON 持久化
-		ragManager = rag.NewRAGManager(ragEmbedder, ragConfig)
+		ragManager = rag.NewRAGManager(activeEmb, ragConfig)
 		ragPersist = rag.NewPersistence(cfg.HomeDir() + "/rag")
 		if ragPersist.Exists() {
 			if docCount, loadErr := ragPersist.Load(ragManager); loadErr == nil && docCount > 0 {
@@ -178,7 +195,7 @@ func New(cfg *config.Manager) (*Agent, error) {
 		ragPersist = rag.NewPersistence(cfg.HomeDir() + "/rag")
 		if ragPersist.Exists() {
 			// 迁移旧 JSON 数据到 SQLite
-			tempMgr := rag.NewRAGManager(ragEmbedder, ragConfig)
+			tempMgr := rag.NewRAGManager(activeEmb, ragConfig)
 			if docCount, loadErr := ragPersist.Load(tempMgr); loadErr == nil && docCount > 0 {
 				for _, docID := range tempMgr.ListDocuments() {
 					if doc, ok := tempMgr.GetDocument(docID); ok {
@@ -204,8 +221,9 @@ func New(cfg *config.Manager) (*Agent, error) {
 		mcpClient:  mcpClient,
 		delegate:   delegateMgr,
 		contextWin: contextWin,
-		ragManager: ragManager,
-		ragPersist: ragPersist,
+		ragManager:  ragManager,
+		ragPersist:  ragPersist,
+		embedderReg: embedderReg,
 	}, nil
 }
 
@@ -536,6 +554,11 @@ func (a *Agent) RAG() *rag.RAGManager {
 // RAGPersist 返回 RAG 持久化管理器
 func (a *Agent) RAGPersist() *rag.Persistence {
 	return a.ragPersist
+}
+
+// EmbedderRegistry 返回嵌入模型注册表
+func (a *Agent) EmbedderRegistry() *embedder.Registry {
+	return a.embedderReg
 }
 
 // Close 释放资源，保存持久化数据

--- a/internal/embedder/embedder.go
+++ b/internal/embedder/embedder.go
@@ -1,0 +1,297 @@
+package embedder
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+)
+
+// Embedder is the interface for embedding providers.
+// It produces vector representations of text for semantic search and RAG.
+type Embedder interface {
+	// Embed returns the embedding vector for the given text.
+	Embed(ctx context.Context, text string) ([]float64, error)
+	// EmbedBatch returns embeddings for multiple texts.
+	EmbedBatch(ctx context.Context, texts []string) ([][]float64, error)
+	// Dimension returns the dimension of the embedding vectors.
+	Dimension() int
+	// Name returns the provider name (e.g. "openai", "ollama").
+	Name() string
+	// Model returns the model identifier (e.g. "text-embedding-3-small").
+	Model() string
+}
+
+// CacheKey generates a deterministic cache key from text.
+func CacheKey(text string) string {
+	h := sha256.Sum256([]byte(text))
+	return hex.EncodeToString(h[:])
+}
+
+// EmbeddingCache provides an LRU cache for embedding results.
+// Same input text always produces the same vector, so caching avoids redundant API calls.
+type EmbeddingCache struct {
+	mu    sync.RWMutex
+	items map[string][]float64
+	order []string // front = oldest, back = newest
+	max   int
+	hits  int64
+	miss  int64
+}
+
+// NewEmbeddingCache creates a new LRU cache with the given capacity.
+// If max <= 0, defaults to 1024.
+func NewEmbeddingCache(max int) *EmbeddingCache {
+	if max <= 0 {
+		max = 1024
+	}
+	return &EmbeddingCache{
+		items: make(map[string][]float64, max),
+		order: make([]string, 0, max),
+		max:   max,
+	}
+}
+
+// Get retrieves a cached embedding. Returns nil if not found.
+// Does NOT promote the entry (LRU promotion only on write).
+func (c *EmbeddingCache) Get(key string) []float64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	vec, ok := c.items[key]
+	if !ok {
+		c.miss++
+		return nil
+	}
+	c.hits++
+	return vec
+}
+
+// Put stores an embedding in the cache, evicting the oldest entry if at capacity.
+// If the key already exists, the value is updated and the entry is promoted.
+func (c *EmbeddingCache) Put(key string, vec []float64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if _, exists := c.items[key]; exists {
+		// Update value and move to end (promote)
+		c.items[key] = vec
+		c.moveToEnd(key)
+		return
+	}
+
+	// Evict oldest if at capacity
+	if len(c.order) >= c.max {
+		oldest := c.order[0]
+		delete(c.items, oldest)
+		c.order = c.order[1:]
+	}
+
+	c.items[key] = vec
+	c.order = append(c.order, key)
+}
+
+// Stats returns cache hit/miss statistics.
+func (c *EmbeddingCache) Stats() (hits, misses int64) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.hits, c.miss
+}
+
+// Len returns the number of cached entries.
+func (c *EmbeddingCache) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.items)
+}
+
+// Clear removes all entries from the cache.
+func (c *EmbeddingCache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.items = make(map[string][]float64, c.max)
+	c.order = c.order[:0]
+	c.hits = 0
+	c.miss = 0
+}
+
+func (c *EmbeddingCache) moveToEnd(key string) {
+	for i, k := range c.order {
+		if k == key {
+			c.order = append(c.order[:i], c.order[i+1:]...)
+			c.order = append(c.order, key)
+			return
+		}
+	}
+}
+
+// CachedEmbedder wraps an Embedder with an LRU cache.
+type CachedEmbedder struct {
+	inner Embedder
+	cache *EmbeddingCache
+}
+
+// NewCachedEmbedder wraps an Embedder with caching.
+func NewCachedEmbedder(inner Embedder, cacheSize int) *CachedEmbedder {
+	return &CachedEmbedder{
+		inner: inner,
+		cache: NewEmbeddingCache(cacheSize),
+	}
+}
+
+// Cache returns the underlying cache for statistics.
+func (ce *CachedEmbedder) Cache() *EmbeddingCache {
+	return ce.cache
+}
+
+func (ce *CachedEmbedder) Name() string      { return ce.inner.Name() }
+func (ce *CachedEmbedder) Model() string     { return ce.inner.Model() }
+func (ce *CachedEmbedder) Dimension() int    { return ce.inner.Dimension() }
+
+func (ce *CachedEmbedder) Embed(ctx context.Context, text string) ([]float64, error) {
+	key := CacheKey(text)
+	if vec := ce.cache.Get(key); vec != nil {
+		return vec, nil
+	}
+	vec, err := ce.inner.Embed(ctx, text)
+	if err != nil {
+		return nil, err
+	}
+	ce.cache.Put(key, vec)
+	return vec, nil
+}
+
+func (ce *CachedEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float64, error) {
+	// Check cache for each text, batch the misses
+	results := make([][]float64, len(texts))
+	misses := make([]int, 0) // indices of uncached texts
+	missTexts := make([]string, 0)
+
+	for i, text := range texts {
+		key := CacheKey(text)
+		if vec := ce.cache.Get(key); vec != nil {
+			results[i] = vec
+		} else {
+			misses = append(misses, i)
+			missTexts = append(missTexts, text)
+		}
+	}
+
+	if len(missTexts) == 0 {
+		return results, nil
+	}
+
+	// Batch embed the misses
+	vecs, err := ce.inner.EmbedBatch(ctx, missTexts)
+	if err != nil {
+		return nil, err
+	}
+
+	for j, idx := range misses {
+		results[idx] = vecs[j]
+		ce.cache.Put(CacheKey(missTexts[j]), vecs[j])
+	}
+
+	return results, nil
+}
+
+// Registry manages multiple embedder providers with registration and switching.
+type Registry struct {
+	mu       sync.RWMutex
+	embedders map[string]Embedder
+	active   string // ID of the active embedder
+}
+
+// NewRegistry creates a new embedder registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		embedders: make(map[string]Embedder),
+	}
+}
+
+// Register adds an embedder to the registry.
+// The id must be unique. Returns false if id already exists.
+func (r *Registry) Register(id string, e Embedder) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.embedders[id]; exists {
+		return false
+	}
+	r.embedders[id] = e
+	if r.active == "" {
+		r.active = id
+	}
+	return true
+}
+
+// Unregister removes an embedder from the registry.
+// Cannot remove the active embedder.
+func (r *Registry) Unregister(id string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if id == r.active {
+		return false // cannot remove active
+	}
+	if _, exists := r.embedders[id]; !exists {
+		return false
+	}
+	delete(r.embedders, id)
+	return true
+}
+
+// Get returns an embedder by ID.
+func (r *Registry) Get(id string) (Embedder, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	e, ok := r.embedders[id]
+	return e, ok
+}
+
+// Active returns the currently active embedder.
+func (r *Registry) Active() Embedder {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.embedders[r.active]
+}
+
+// ActiveID returns the ID of the active embedder.
+func (r *Registry) ActiveID() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.active
+}
+
+// Switch changes the active embedder. Returns false if id not found.
+func (r *Registry) Switch(id string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.embedders[id]; !exists {
+		return false
+	}
+	r.active = id
+	return true
+}
+
+// List returns all registered embedder IDs and their info.
+type EmbedderInfo struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Model     string `json:"model"`
+	Dimension int    `json:"dimension"`
+	Active    bool   `json:"active"`
+}
+
+func (r *Registry) List() []EmbedderInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	result := make([]EmbedderInfo, 0, len(r.embedders))
+	for id, e := range r.embedders {
+		result = append(result, EmbedderInfo{
+			ID:        id,
+			Name:      e.Name(),
+			Model:     e.Model(),
+			Dimension: e.Dimension(),
+			Active:    id == r.active,
+		})
+	}
+	return result
+}

--- a/internal/embedder/embedder_test.go
+++ b/internal/embedder/embedder_test.go
@@ -1,0 +1,500 @@
+package embedder
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestMockEmbedder(t *testing.T) {
+	e := NewMockEmbedder(64)
+	if e.Name() != "mock" {
+		t.Errorf("Name() = %q, want %q", e.Name(), "mock")
+	}
+	if e.Dimension() != 64 {
+		t.Errorf("Dimension() = %d, want 64", e.Dimension())
+	}
+
+	vec, err := e.Embed(context.Background(), "hello world")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vec) != 64 {
+		t.Errorf("Embed() len = %d, want 64", len(vec))
+	}
+
+	// Deterministic
+	vec2, _ := e.Embed(context.Background(), "hello world")
+	for i := range vec {
+		if vec[i] != vec2[i] {
+			t.Error("Embed() not deterministic")
+			break
+		}
+	}
+
+	// Different text → different vector
+	vec3, _ := e.Embed(context.Background(), "goodbye world")
+	same := true
+	for i := range vec {
+		if vec[i] != vec3[i] {
+			same = false
+			break
+		}
+	}
+	if same {
+		t.Error("different text produced same vector")
+	}
+}
+
+func TestMockEmbedderBatch(t *testing.T) {
+	e := NewMockEmbedder(32)
+	vecs, err := e.EmbedBatch(context.Background(), []string{"a", "b", "c"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vecs) != 3 {
+		t.Errorf("EmbedBatch() len = %d, want 3", len(vecs))
+	}
+	for i, v := range vecs {
+		if len(v) != 32 {
+			t.Errorf("vec[%d] len = %d, want 32", i, len(v))
+		}
+	}
+}
+
+func TestMockEmbedderDefaultDim(t *testing.T) {
+	e := NewMockEmbedder(0)
+	if e.Dimension() != 128 {
+		t.Errorf("Dimension() = %d, want 128", e.Dimension())
+	}
+}
+
+func TestMockEmbedderWithModel(t *testing.T) {
+	e := NewMockEmbedderWithModel(64, "custom-mock")
+	if e.Model() != "custom-mock" {
+		t.Errorf("Model() = %q, want %q", e.Model(), "custom-mock")
+	}
+}
+
+func TestOpenAIEmbedder(t *testing.T) {
+	e := NewOpenAIEmbedder(OpenAIEmbedderConfig{})
+	if e.Name() != "openai" {
+		t.Errorf("Name() = %q, want %q", e.Name(), "openai")
+	}
+	if e.Model() != "text-embedding-3-small" {
+		t.Errorf("Model() = %q, want %q", e.Model(), "text-embedding-3-small")
+	}
+	if e.Dimension() != 1536 {
+		t.Errorf("Dimension() = %d, want 1536", e.Dimension())
+	}
+
+	vec, err := e.Embed(context.Background(), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vec) != 1536 {
+		t.Errorf("Embed() len = %d, want 1536", len(vec))
+	}
+}
+
+func TestOpenAIEmbedderLarge(t *testing.T) {
+	e := NewOpenAIEmbedder(OpenAIEmbedderConfig{Model: "text-embedding-3-large"})
+	if e.Dimension() != 3072 {
+		t.Errorf("Dimension() = %d, want 3072", e.Dimension())
+	}
+}
+
+func TestOpenAIEmbedderCustomBaseURL(t *testing.T) {
+	e := NewOpenAIEmbedder(OpenAIEmbedderConfig{
+		BaseURL: "https://my-proxy.example.com/v1",
+		Model:   "text-embedding-3-small",
+	})
+	if e.Name() != "openai" {
+		t.Errorf("Name() = %q", e.Name())
+	}
+}
+
+func TestOllamaEmbedder(t *testing.T) {
+	e := NewOllamaEmbedder(OllamaEmbedderConfig{})
+	if e.Name() != "ollama" {
+		t.Errorf("Name() = %q, want %q", e.Name(), "ollama")
+	}
+	if e.Model() != "nomic-embed-text" {
+		t.Errorf("Model() = %q, want %q", e.Model(), "nomic-embed-text")
+	}
+	if e.Dimension() != 768 {
+		t.Errorf("Dimension() = %d, want 768", e.Dimension())
+	}
+
+	vec, err := e.Embed(context.Background(), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vec) != 768 {
+		t.Errorf("Embed() len = %d, want 768", len(vec))
+	}
+}
+
+func TestOllamaEmbedderMxbai(t *testing.T) {
+	e := NewOllamaEmbedder(OllamaEmbedderConfig{Model: "mxbai-embed-large"})
+	if e.Dimension() != 1024 {
+		t.Errorf("Dimension() = %d, want 1024", e.Dimension())
+	}
+}
+
+// --- Cache tests ---
+
+func TestEmbeddingCacheBasic(t *testing.T) {
+	c := NewEmbeddingCache(4)
+	vec := []float64{1.0, 2.0, 3.0}
+
+	c.Put("key1", vec)
+	got := c.Get("key1")
+	if got == nil {
+		t.Fatal("Get() returned nil")
+	}
+	for i := range got {
+		if got[i] != vec[i] {
+			t.Errorf("Get() = %v, want %v", got, vec)
+			break
+		}
+	}
+
+	if c.Get("nonexistent") != nil {
+		t.Error("Get() should return nil for missing key")
+	}
+}
+
+func TestEmbeddingCacheLRUEviction(t *testing.T) {
+	c := NewEmbeddingCache(2)
+	c.Put("a", []float64{1})
+	c.Put("b", []float64{2})
+
+	// Cache is full. Adding "c" evicts "a" (oldest).
+	c.Put("c", []float64{3})
+
+	if c.Get("a") != nil {
+		t.Error("a should have been evicted")
+	}
+	if c.Get("b") == nil {
+		t.Error("b should still be cached")
+	}
+	if c.Get("c") == nil {
+		t.Error("c should be cached")
+	}
+}
+
+func TestEmbeddingCacheLRUAccessPromotes(t *testing.T) {
+	c := NewEmbeddingCache(2)
+	c.Put("a", []float64{1})
+	c.Put("b", []float64{2})
+
+	// Re-put "a" to promote it (Get does not promote in this LRU implementation)
+	c.Put("a", []float64{1})
+
+	// Adding "c" should evict "b" (now oldest), not "a"
+	c.Put("c", []float64{3})
+
+	if c.Get("a") == nil {
+		t.Error("a should still be cached (was promoted)")
+	}
+	if c.Get("b") != nil {
+		t.Error("b should have been evicted")
+	}
+}
+
+func TestEmbeddingCacheStats(t *testing.T) {
+	c := NewEmbeddingCache(10)
+	c.Put("key", []float64{1})
+
+	_ = c.Get("key")   // hit
+	_ = c.Get("key")   // hit
+	_ = c.Get("miss1") // miss
+	_ = c.Get("miss2") // miss
+
+	hits, misses := c.Stats()
+	if hits != 2 {
+		t.Errorf("hits = %d, want 2", hits)
+	}
+	if misses != 2 {
+		t.Errorf("misses = %d, want 2", misses)
+	}
+}
+
+func TestEmbeddingCacheClear(t *testing.T) {
+	c := NewEmbeddingCache(10)
+	c.Put("a", []float64{1})
+	c.Put("b", []float64{2})
+	c.Clear()
+
+	if c.Len() != 0 {
+		t.Errorf("Len() = %d after Clear(), want 0", c.Len())
+	}
+	hits, _ := c.Stats()
+	if hits != 0 {
+		t.Errorf("hits = %d after Clear(), want 0", hits)
+	}
+}
+
+func TestEmbeddingCachePutDuplicate(t *testing.T) {
+	c := NewEmbeddingCache(10)
+	c.Put("key", []float64{1})
+	c.Put("key", []float64{2}) // overwrite
+
+	got := c.Get("key")
+	if got == nil || got[0] != 2.0 {
+		t.Errorf("Get() = %v, want [2]", got)
+	}
+	if c.Len() != 1 {
+		t.Errorf("Len() = %d, want 1", c.Len())
+	}
+}
+
+// --- CachedEmbedder tests ---
+
+func TestCachedEmbedderCachesResults(t *testing.T) {
+	inner := NewMockEmbedder(32)
+	ce := NewCachedEmbedder(inner, 100)
+
+	vec1, err := ce.Embed(context.Background(), "hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+	vec2, err := ce.Embed(context.Background(), "hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Same result from cache
+	for i := range vec1 {
+		if vec1[i] != vec2[i] {
+			t.Error("cached result differs from original")
+			break
+		}
+	}
+
+	hits, _ := ce.Cache().Stats()
+	if hits != 1 {
+		t.Errorf("cache hits = %d, want 1", hits)
+	}
+}
+
+func TestCachedEmbedderBatch(t *testing.T) {
+	inner := NewMockEmbedder(16)
+	ce := NewCachedEmbedder(inner, 100)
+
+	vecs, err := ce.EmbedBatch(context.Background(), []string{"a", "b", "c"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vecs) != 3 {
+		t.Errorf("EmbedBatch() len = %d, want 3", len(vecs))
+	}
+
+	// Second call should hit cache
+	vecs2, err := ce.EmbedBatch(context.Background(), []string{"a", "b", "c"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range vecs {
+		for j := range vecs[i] {
+			if vecs[i][j] != vecs2[i][j] {
+				t.Errorf("cached batch result differs at [%d][%d]", i, j)
+			}
+		}
+	}
+}
+
+func TestCachedEmbedderBatchPartialCache(t *testing.T) {
+	inner := NewMockEmbedder(16)
+	ce := NewCachedEmbedder(inner, 100)
+
+	// Pre-cache "a"
+	_, _ = ce.Embed(context.Background(), "a")
+
+	// Batch with "a" (cached) + "b" (miss) + "c" (miss)
+	vecs, err := ce.EmbedBatch(context.Background(), []string{"a", "b", "c"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vecs) != 3 {
+		t.Errorf("EmbedBatch() len = %d, want 3", len(vecs))
+	}
+
+	// "a" should have been a cache hit
+	hits, misses := ce.Cache().Stats()
+	if hits < 1 {
+		t.Errorf("expected at least 1 cache hit, got hits=%d misses=%d", hits, misses)
+	}
+}
+
+// --- Registry tests ---
+
+func TestRegistryBasic(t *testing.T) {
+	r := NewRegistry()
+	e1 := NewMockEmbedder(64)
+	e2 := NewMockEmbedder(128)
+
+	if !r.Register("mock-64", e1) {
+		t.Error("Register() should succeed for new ID")
+	}
+	if r.Register("mock-64", e2) {
+		t.Error("Register() should fail for duplicate ID")
+	}
+	if !r.Register("mock-128", e2) {
+		t.Error("Register() should succeed for new ID")
+	}
+
+	// First registered becomes active
+	if r.ActiveID() != "mock-64" {
+		t.Errorf("ActiveID() = %q, want %q", r.ActiveID(), "mock-64")
+	}
+
+	active := r.Active()
+	if active == nil {
+		t.Fatal("Active() returned nil")
+	}
+	if active.Dimension() != 64 {
+		t.Errorf("Active().Dimension() = %d, want 64", active.Dimension())
+	}
+}
+
+func TestRegistrySwitch(t *testing.T) {
+	r := NewRegistry()
+	r.Register("a", NewMockEmbedder(64))
+	r.Register("b", NewMockEmbedder(128))
+
+	if !r.Switch("b") {
+		t.Error("Switch() should succeed for existing ID")
+	}
+	if r.ActiveID() != "b" {
+		t.Errorf("ActiveID() = %q, want %q", r.ActiveID(), "b")
+	}
+	if r.Active().Dimension() != 128 {
+		t.Errorf("Active().Dimension() = %d, want 128", r.Active().Dimension())
+	}
+
+	if r.Switch("nonexistent") {
+		t.Error("Switch() should fail for nonexistent ID")
+	}
+}
+
+func TestRegistryUnregister(t *testing.T) {
+	r := NewRegistry()
+	r.Register("a", NewMockEmbedder(64))
+	r.Register("b", NewMockEmbedder(128))
+
+	// Cannot remove active
+	if r.Unregister("a") {
+		t.Error("Unregister() should fail for active embedder")
+	}
+
+	// Can remove non-active
+	if !r.Unregister("b") {
+		t.Error("Unregister() should succeed for non-active embedder")
+	}
+
+	// Nonexistent
+	if r.Unregister("nonexistent") {
+		t.Error("Unregister() should fail for nonexistent ID")
+	}
+}
+
+func TestRegistryList(t *testing.T) {
+	r := NewRegistry()
+	r.Register("mock-64", NewMockEmbedder(64))
+	r.Register("mock-128", NewMockEmbedder(128))
+
+	list := r.List()
+	if len(list) != 2 {
+		t.Fatalf("List() len = %d, want 2", len(list))
+	}
+
+	// Find the active one
+	var foundActive bool
+	for _, info := range list {
+		if info.Active {
+			foundActive = true
+			if info.ID != "mock-64" {
+				t.Errorf("active ID = %q, want %q", info.ID, "mock-64")
+			}
+		}
+	}
+	if !foundActive {
+		t.Error("no active embedder in List()")
+	}
+}
+
+func TestRegistryGet(t *testing.T) {
+	r := NewRegistry()
+	e := NewMockEmbedder(64)
+	r.Register("test", e)
+
+	got, ok := r.Get("test")
+	if !ok {
+		t.Error("Get() should find registered embedder")
+	}
+	if got.Dimension() != 64 {
+		t.Errorf("Get().Dimension() = %d, want 64", got.Dimension())
+	}
+
+	_, ok = r.Get("nonexistent")
+	if ok {
+		t.Error("Get() should not find unregistered embedder")
+	}
+}
+
+func TestCacheKeyDeterministic(t *testing.T) {
+	k1 := CacheKey("hello world")
+	k2 := CacheKey("hello world")
+	if k1 != k2 {
+		t.Error("CacheKey() not deterministic")
+	}
+
+	k3 := CacheKey("goodbye world")
+	if k1 == k3 {
+		t.Error("different text produced same CacheKey")
+	}
+}
+
+func TestCacheConcurrent(t *testing.T) {
+	c := NewEmbeddingCache(100)
+	var wg sync.WaitGroup
+
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			c.Put(string(rune('a'+i%26)), []float64{float64(i)})
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			_ = c.Get(string(rune('a' + i%26)))
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestRegistryConcurrent(t *testing.T) {
+	r := NewRegistry()
+	r.Register("base", NewMockEmbedder(64))
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(3)
+		go func(i int) {
+			defer wg.Done()
+			r.Register(fmt.Sprintf("e-%d", i), NewMockEmbedder(32+i%64))
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			_ = r.Active()
+		}(i)
+		go func() {
+			defer wg.Done()
+			_ = r.List()
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/embedder/providers.go
+++ b/internal/embedder/providers.go
@@ -1,0 +1,215 @@
+package embedder
+
+import (
+	"context"
+	"fmt"
+	"math"
+)
+
+// MockEmbedder is a deterministic hash-based embedder for testing.
+type MockEmbedder struct {
+	dim   int
+	model string
+}
+
+// NewMockEmbedder creates a mock embedder with the given dimension.
+func NewMockEmbedder(dim int) *MockEmbedder {
+	if dim <= 0 {
+		dim = 128
+	}
+	return &MockEmbedder{dim: dim, model: "mock-embedding"}
+}
+
+// NewMockEmbedderWithModel creates a mock embedder with a custom model name.
+func NewMockEmbedderWithModel(dim int, model string) *MockEmbedder {
+	if dim <= 0 {
+		dim = 128
+	}
+	return &MockEmbedder{dim: dim, model: model}
+}
+
+func (m *MockEmbedder) Name() string      { return "mock" }
+func (m *MockEmbedder) Model() string     { return m.model }
+func (m *MockEmbedder) Dimension() int    { return m.dim }
+
+func (m *MockEmbedder) Embed(_ context.Context, text string) ([]float64, error) {
+	return mockVector(text, m.dim), nil
+}
+
+func (m *MockEmbedder) EmbedBatch(_ context.Context, texts []string) ([][]float64, error) {
+	result := make([][]float64, len(texts))
+	for i, t := range texts {
+		result[i] = mockVector(t, m.dim)
+	}
+	return result, nil
+}
+
+// mockVector generates a deterministic pseudo-random vector from text.
+func mockVector(text string, dim int) []float64 {
+	vec := make([]float64, dim)
+	if len(text) == 0 {
+		return vec
+	}
+	for i, ch := range text {
+		idx := i % dim
+		vec[idx] += float64(ch)
+	}
+	norm := 0.0
+	for _, v := range vec {
+		norm += v * v
+	}
+	norm = math.Sqrt(norm)
+	if norm > 0 {
+		for i := range vec {
+			vec[i] /= norm
+		}
+	}
+	return vec
+}
+
+// OpenAIEmbedder calls OpenAI-compatible embedding APIs.
+// Supports text-embedding-3-small, text-embedding-3-large, text-embedding-ada-002,
+// and any OpenAI-compatible endpoint (e.g. Azure, local proxies).
+type OpenAIEmbedder struct {
+	apiKey    string
+	model     string
+	baseURL   string
+	dimension int
+}
+
+// OpenAIEmbedderConfig configures an OpenAI embedder.
+type OpenAIEmbedderConfig struct {
+	APIKey    string
+	Model     string // defaults to "text-embedding-3-small"
+	BaseURL   string // defaults to "https://api.openai.com/v1"
+	Dimension int    // defaults to model's native dimension
+}
+
+// NewOpenAIEmbedder creates an OpenAI embedder.
+func NewOpenAIEmbedder(cfg OpenAIEmbedderConfig) *OpenAIEmbedder {
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = "https://api.openai.com/v1"
+	}
+	model := cfg.Model
+	if model == "" {
+		model = "text-embedding-3-small"
+	}
+	dim := cfg.Dimension
+	if dim <= 0 {
+		dim = openAIDefaultDim(model)
+	}
+	return &OpenAIEmbedder{
+		apiKey:    cfg.APIKey,
+		model:     model,
+		baseURL:   baseURL,
+		dimension: dim,
+	}
+}
+
+func openAIDefaultDim(model string) int {
+	switch model {
+	case "text-embedding-3-small":
+		return 1536
+	case "text-embedding-3-large":
+		return 3072
+	case "text-embedding-ada-002":
+		return 1536
+	default:
+		return 1536
+	}
+}
+
+func (o *OpenAIEmbedder) Name() string      { return "openai" }
+func (o *OpenAIEmbedder) Model() string     { return o.model }
+func (o *OpenAIEmbedder) Dimension() int    { return o.dimension }
+
+func (o *OpenAIEmbedder) Embed(ctx context.Context, text string) ([]float64, error) {
+	vecs, err := o.EmbedBatch(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(vecs) == 0 {
+		return nil, fmt.Errorf("no embedding returned")
+	}
+	return vecs[0], nil
+}
+
+func (o *OpenAIEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float64, error) {
+	// TODO: implement real HTTP call to OpenAI embeddings API
+	// POST {baseURL}/embeddings with model + input array
+	// For now, fall back to mock vectors so the pipeline works without API keys.
+	mock := NewMockEmbedder(o.dimension)
+	return mock.EmbedBatch(ctx, texts)
+}
+
+// OllamaEmbedder calls Ollama's embedding API.
+// Supports models like nomic-embed-text, mxbai-embed-large, etc.
+type OllamaEmbedder struct {
+	baseURL   string
+	model     string
+	dimension int
+}
+
+// OllamaEmbedderConfig configures an Ollama embedder.
+type OllamaEmbedderConfig struct {
+	BaseURL   string // defaults to "http://localhost:11434"
+	Model     string // defaults to "nomic-embed-text"
+	Dimension int    // defaults to model's native dimension
+}
+
+// NewOllamaEmbedder creates an Ollama embedder.
+func NewOllamaEmbedder(cfg OllamaEmbedderConfig) *OllamaEmbedder {
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = "http://localhost:11434"
+	}
+	model := cfg.Model
+	if model == "" {
+		model = "nomic-embed-text"
+	}
+	dim := cfg.Dimension
+	if dim <= 0 {
+		dim = ollamaDefaultDim(model)
+	}
+	return &OllamaEmbedder{
+		baseURL:   baseURL,
+		model:     model,
+		dimension: dim,
+	}
+}
+
+func ollamaDefaultDim(model string) int {
+	switch model {
+	case "nomic-embed-text":
+		return 768
+	case "mxbai-embed-large":
+		return 1024
+	case "all-minilm":
+		return 384
+	default:
+		return 768
+	}
+}
+
+func (o *OllamaEmbedder) Name() string      { return "ollama" }
+func (o *OllamaEmbedder) Model() string     { return o.model }
+func (o *OllamaEmbedder) Dimension() int    { return o.dimension }
+
+func (o *OllamaEmbedder) Embed(ctx context.Context, text string) ([]float64, error) {
+	vecs, err := o.EmbedBatch(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(vecs) == 0 {
+		return nil, fmt.Errorf("no embedding returned")
+	}
+	return vecs[0], nil
+}
+
+func (o *OllamaEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float64, error) {
+	// TODO: implement real HTTP call to Ollama /api/embeddings
+	// For now, fall back to mock vectors.
+	mock := NewMockEmbedder(o.dimension)
+	return mock.EmbedBatch(ctx, texts)
+}

--- a/internal/rag/embedder.go
+++ b/internal/rag/embedder.go
@@ -2,133 +2,29 @@ package rag
 
 import (
 	"context"
-	"fmt"
-	"math"
+
+	"github.com/yurika0211/luckyharness/internal/embedder"
 )
 
 // EmbeddingProvider provides vector embeddings for text.
-type EmbeddingProvider interface {
-	// Embed returns the embedding vector for the given text.
-	Embed(ctx context.Context, text string) ([]float64, error)
-	// EmbedBatch returns embeddings for multiple texts.
-	EmbedBatch(ctx context.Context, texts []string) ([][]float64, error)
-	// Dimension returns the dimension of the embedding vectors.
-	Dimension() int
-	// Name returns the provider name.
-	Name() string
+// Deprecated: Use embedder.Embedder instead. This interface is kept for backward compatibility.
+// embedder.Embedder satisfies this interface (it has Embed, EmbedBatch, Dimension, Name).
+type EmbeddingProvider = embedder.Embedder
+
+// NewMockEmbedder creates a mock embedder for testing (delegates to embedder package).
+func NewMockEmbedder(dim int) *embedder.MockEmbedder {
+	return embedder.NewMockEmbedder(dim)
 }
 
-// MockEmbedder is a simple embedder for testing that uses hash-based vectors.
-type MockEmbedder struct {
-	dim int
-}
-
-func NewMockEmbedder(dim int) *MockEmbedder {
-	if dim <= 0 {
-		dim = 128
-	}
-	return &MockEmbedder{dim: dim}
-}
-
-func (m *MockEmbedder) Name() string { return "mock" }
-
-func (m *MockEmbedder) Dimension() int { return m.dim }
-
-func (m *MockEmbedder) Embed(_ context.Context, text string) ([]float64, error) {
-	return mockVector(text, m.dim), nil
-}
-
-func (m *MockEmbedder) EmbedBatch(_ context.Context, texts []string) ([][]float64, error) {
-	result := make([][]float64, len(texts))
-	for i, t := range texts {
-		result[i] = mockVector(t, m.dim)
-	}
-	return result, nil
+// NewOpenAIEmbedder creates an OpenAI embedder (delegates to embedder package).
+func NewOpenAIEmbedder(cfg embedder.OpenAIEmbedderConfig) *embedder.OpenAIEmbedder {
+	return embedder.NewOpenAIEmbedder(cfg)
 }
 
 // mockVector generates a deterministic pseudo-random vector from text.
-// Uses a simple hash-based approach for reproducibility in tests.
+// Kept for backward compatibility with existing tests.
 func mockVector(text string, dim int) []float64 {
-	vec := make([]float64, dim)
-	if len(text) == 0 {
-		return vec
-	}
-	// Simple hash: distribute characters across dimensions
-	for i, ch := range text {
-		idx := i % dim
-		vec[idx] += float64(ch)
-	}
-	// Normalize
-	norm := 0.0
-	for _, v := range vec {
-		norm += v * v
-	}
-	norm = math.Sqrt(norm)
-	if norm > 0 {
-		for i := range vec {
-			vec[i] /= norm
-		}
-	}
+	e := embedder.NewMockEmbedder(dim)
+	vec, _ := e.Embed(context.Background(), text)
 	return vec
-}
-
-// OpenAIEmbedder calls OpenAI's embedding API.
-type OpenAIEmbedder struct {
-	apiKey     string
-	model      string
-	baseURL    string
-	dimension  int
-	httpClient interface{} // *http.Client, kept as interface to avoid import
-}
-
-type OpenAIEmbedderConfig struct {
-	APIKey    string
-	Model     string
-	BaseURL   string // defaults to https://api.openai.com/v1
-	Dimension int    // defaults to model's native dimension
-}
-
-func NewOpenAIEmbedder(cfg OpenAIEmbedderConfig) *OpenAIEmbedder {
-	baseURL := cfg.BaseURL
-	if baseURL == "" {
-		baseURL = "https://api.openai.com/v1"
-	}
-	model := cfg.Model
-	if model == "" {
-		model = "text-embedding-3-small"
-	}
-	dim := cfg.Dimension
-	if dim <= 0 {
-		dim = 1536 // text-embedding-3-small default
-	}
-	return &OpenAIEmbedder{
-		apiKey:    cfg.APIKey,
-		model:     model,
-		baseURL:   baseURL,
-		dimension: dim,
-	}
-}
-
-func (o *OpenAIEmbedder) Name() string { return "openai-embedding" }
-
-func (o *OpenAIEmbedder) Dimension() int { return o.dimension }
-
-func (o *OpenAIEmbedder) Embed(ctx context.Context, text string) ([]float64, error) {
-	vecs, err := o.EmbedBatch(ctx, []string{text})
-	if err != nil {
-		return nil, err
-	}
-	if len(vecs) == 0 {
-		return nil, fmt.Errorf("no embedding returned")
-	}
-	return vecs[0], nil
-}
-
-func (o *OpenAIEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float64, error) {
-	// This is a placeholder implementation.
-	// In production, this would call the OpenAI embeddings API:
-	// POST {baseURL}/embeddings with model + input array
-	// For now, return mock vectors to allow the RAG pipeline to work without API keys.
-	embedder := NewMockEmbedder(o.dimension)
-	return embedder.EmbedBatch(ctx, texts)
 }

--- a/internal/rag/rag_test.go
+++ b/internal/rag/rag_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/yurika0211/luckyharness/internal/embedder"
 )
 
 func TestMockEmbedder(t *testing.T) {
@@ -66,15 +68,15 @@ func TestMockEmbedderBatch(t *testing.T) {
 }
 
 func TestOpenAIEmbedder(t *testing.T) {
-	cfg := OpenAIEmbedderConfig{
+	cfg := embedder.OpenAIEmbedderConfig{
 		APIKey:    "test-key",
 		Model:     "text-embedding-3-small",
 		Dimension: 256,
 	}
 	e := NewOpenAIEmbedder(cfg)
 
-	if e.Name() != "openai-embedding" {
-		t.Errorf("expected name 'openai-embedding', got %s", e.Name())
+	if e.Name() != "openai" {
+		t.Errorf("expected name 'openai', got %s", e.Name())
 	}
 	if e.Dimension() != 256 {
 		t.Errorf("expected dimension 256, got %d", e.Dimension())
@@ -91,7 +93,7 @@ func TestOpenAIEmbedder(t *testing.T) {
 }
 
 func TestOpenAIEmbedderDefaults(t *testing.T) {
-	e := NewOpenAIEmbedder(OpenAIEmbedderConfig{})
+	e := NewOpenAIEmbedder(embedder.OpenAIEmbedderConfig{})
 	if e.Dimension() != 1536 {
 		t.Errorf("expected default dimension 1536, got %d", e.Dimension())
 	}

--- a/internal/server/embedder_handlers.go
+++ b/internal/server/embedder_handlers.go
@@ -1,0 +1,204 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/yurika0211/luckyharness/internal/embedder"
+)
+
+// --- v0.21.0: Embedder API handlers ---
+
+func (s *Server) handleEmbedderList(w http.ResponseWriter, r *http.Request) {
+	reg := s.agent.EmbedderRegistry()
+	if reg == nil {
+		s.sendJSON(w, http.StatusOK, []embedder.EmbedderInfo{})
+		return
+	}
+	s.sendJSON(w, http.StatusOK, reg.List())
+}
+
+func (s *Server) handleEmbedderGet(w http.ResponseWriter, r *http.Request, id string) {
+	reg := s.agent.EmbedderRegistry()
+	if reg == nil {
+		s.sendError(w, "embedder registry not available", http.StatusNotFound, "")
+		return
+	}
+
+	e, ok := reg.Get(id)
+	if !ok {
+		s.sendError(w, "embedder not found: "+id, http.StatusNotFound, "")
+		return
+	}
+
+	info := embedder.EmbedderInfo{
+		ID:        id,
+		Name:      e.Name(),
+		Model:     e.Model(),
+		Dimension: e.Dimension(),
+		Active:    reg.ActiveID() == id,
+	}
+	s.sendJSON(w, http.StatusOK, info)
+}
+
+type embedderSwitchRequest struct {
+	ID string `json:"id"`
+}
+
+func (s *Server) handleEmbedderSwitch(w http.ResponseWriter, r *http.Request) {
+	var req embedderSwitchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.sendError(w, "invalid request body", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	reg := s.agent.EmbedderRegistry()
+	if reg == nil {
+		s.sendError(w, "embedder registry not available", http.StatusNotFound, "")
+		return
+	}
+
+	if !reg.Switch(req.ID) {
+		s.sendError(w, "embedder not found: "+req.ID, http.StatusNotFound, "")
+		return
+	}
+
+	e := reg.Active()
+	s.sendJSON(w, http.StatusOK, map[string]interface{}{
+		"active":    req.ID,
+		"name":      e.Name(),
+		"model":     e.Model(),
+		"dimension": e.Dimension(),
+	})
+}
+
+type embedderRegisterRequest struct {
+	ID        string `json:"id"`
+	Provider  string `json:"provider"`  // "mock", "openai", "ollama"
+	Model     string `json:"model"`
+	Dimension int    `json:"dimension,omitempty"`
+	APIKey    string `json:"api_key,omitempty"`
+	BaseURL   string `json:"base_url,omitempty"`
+}
+
+func (s *Server) handleEmbedderRegister(w http.ResponseWriter, r *http.Request) {
+	var req embedderRegisterRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.sendError(w, "invalid request body", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	reg := s.agent.EmbedderRegistry()
+	if reg == nil {
+		s.sendError(w, "embedder registry not available", http.StatusInternalServerError, "")
+		return
+	}
+
+	var e embedder.Embedder
+	switch req.Provider {
+	case "mock":
+		e = embedder.NewMockEmbedderWithModel(req.Dimension, req.Model)
+	case "openai":
+		e = embedder.NewOpenAIEmbedder(embedder.OpenAIEmbedderConfig{
+			APIKey:    req.APIKey,
+			Model:     req.Model,
+			BaseURL:   req.BaseURL,
+			Dimension: req.Dimension,
+		})
+	case "ollama":
+		e = embedder.NewOllamaEmbedder(embedder.OllamaEmbedderConfig{
+			BaseURL:   req.BaseURL,
+			Model:     req.Model,
+			Dimension: req.Dimension,
+		})
+	default:
+		s.sendError(w, "unknown provider: "+req.Provider, http.StatusBadRequest, "")
+		return
+	}
+
+	if !reg.Register(req.ID, e) {
+		s.sendError(w, "embedder already registered: "+req.ID, http.StatusConflict, "")
+		return
+	}
+
+	s.sendJSON(w, http.StatusCreated, map[string]interface{}{
+		"id":        req.ID,
+		"name":      e.Name(),
+		"model":     e.Model(),
+		"dimension": e.Dimension(),
+	})
+}
+
+type embedderTestRequest struct {
+	Text string `json:"text"`
+}
+
+func (s *Server) handleEmbedderTest(w http.ResponseWriter, r *http.Request, id string) {
+	var req embedderTestRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.sendError(w, "invalid request body", http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if req.Text == "" {
+		req.Text = "Hello, world!"
+	}
+
+	reg := s.agent.EmbedderRegistry()
+	if reg == nil {
+		s.sendError(w, "embedder registry not available", http.StatusNotFound, "")
+		return
+	}
+
+	e, ok := reg.Get(id)
+	if !ok {
+		s.sendError(w, "embedder not found: "+id, http.StatusNotFound, "")
+		return
+	}
+
+	vec, err := e.Embed(r.Context(), req.Text)
+	if err != nil {
+		s.sendError(w, "embedding failed", http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	sampleLen := 5
+	if len(vec) < sampleLen {
+		sampleLen = len(vec)
+	}
+	sample := make([]float64, sampleLen)
+	copy(sample, vec[:sampleLen])
+
+	s.sendJSON(w, http.StatusOK, map[string]interface{}{
+		"id":        id,
+		"text":      req.Text,
+		"dimension": len(vec),
+		"sample":    sample,
+	})
+}
+
+// handleEmbedderRoutes dispatches /api/v1/embedders/{id} and /api/v1/embedders/{id}/test
+func (s *Server) handleEmbedderRoutes(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Path
+	suffix := strings.TrimPrefix(path, "/api/v1/embedders/")
+	if suffix == "" {
+		s.handleEmbedderList(w, r)
+		return
+	}
+
+	parts := strings.SplitN(suffix, "/", 2)
+	id := parts[0]
+
+	if len(parts) == 2 && parts[1] == "test" {
+		s.handleEmbedderTest(w, r, id)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		s.handleEmbedderGet(w, r, id)
+	default:
+		s.sendError(w, "method not allowed", http.StatusMethodNotAllowed, "")
+	}
+}

--- a/internal/server/embedder_handlers_test.go
+++ b/internal/server/embedder_handlers_test.go
@@ -1,0 +1,208 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newEmbedderTestServer(t *testing.T) *Server {
+	t.Helper()
+	a := createTestAgent(t)
+	return New(a, DefaultServerConfig())
+}
+
+func TestEmbedderList(t *testing.T) {
+	s := newEmbedderTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/embedders", nil)
+	w := httptest.NewRecorder()
+	s.handleEmbedderList(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var list []map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&list); err != nil {
+		t.Fatal(err)
+	}
+	if len(list) == 0 {
+		t.Error("expected at least one embedder registered")
+	}
+}
+
+func TestEmbedderGet(t *testing.T) {
+	s := newEmbedderTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/embedders/mock-128", nil)
+	w := httptest.NewRecorder()
+	s.handleEmbedderGet(w, req, "mock-128")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var info map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&info); err != nil {
+		t.Fatal(err)
+	}
+	if info["id"] != "mock-128" {
+		t.Errorf("id = %v, want mock-128", info["id"])
+	}
+}
+
+func TestEmbedderGetNotFound(t *testing.T) {
+	s := newEmbedderTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/embedders/nonexistent", nil)
+	w := httptest.NewRecorder()
+	s.handleEmbedderGet(w, req, "nonexistent")
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestEmbedderRegister(t *testing.T) {
+	s := newEmbedderTestServer(t)
+
+	body := `{"id":"test-mock","provider":"mock","model":"test-model","dimension":64}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/embedders/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.handleEmbedderRegister(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["id"] != "test-mock" {
+		t.Errorf("id = %v, want test-mock", resp["id"])
+	}
+}
+
+func TestEmbedderRegisterDuplicate(t *testing.T) {
+	s := newEmbedderTestServer(t)
+
+	body := `{"id":"mock-128","provider":"mock","model":"dup","dimension":64}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/embedders/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.handleEmbedderRegister(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", w.Code)
+	}
+}
+
+func TestEmbedderSwitch(t *testing.T) {
+	s := newEmbedderTestServer(t)
+
+	// Register a second embedder first
+	body := `{"id":"test-64","provider":"mock","model":"test","dimension":64}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/embedders/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.handleEmbedderRegister(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("register: status = %d, want 201", w.Code)
+	}
+
+	// Switch to it
+	switchBody := `{"id":"test-64"}`
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/embedders/switch", strings.NewReader(switchBody))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	s.handleEmbedderSwitch(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("switch: status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["active"] != "test-64" {
+		t.Errorf("active = %v, want test-64", resp["active"])
+	}
+}
+
+func TestEmbedderSwitchNotFound(t *testing.T) {
+	s := newEmbedderTestServer(t)
+
+	body := `{"id":"nonexistent"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/embedders/switch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.handleEmbedderSwitch(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestEmbedderTest(t *testing.T) {
+	s := newEmbedderTestServer(t)
+
+	body := `{"text":"hello world"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/embedders/mock-128/test", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.handleEmbedderTest(w, req, "mock-128")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["dimension"] == nil {
+		t.Error("expected dimension in response")
+	}
+}
+
+func TestEmbedderRegisterUnknownProvider(t *testing.T) {
+	s := newEmbedderTestServer(t)
+
+	body := `{"id":"bad","provider":"unknown","model":"x","dimension":64}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/embedders/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.handleEmbedderRegister(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestEmbedderRegisterOllama(t *testing.T) {
+	s := newEmbedderTestServer(t)
+
+	body := `{"id":"local-ollama","provider":"ollama","model":"nomic-embed-text","dimension":768}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/embedders/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.handleEmbedderRegister(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["name"] != "ollama" {
+		t.Errorf("name = %v, want ollama", resp["name"])
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -136,7 +136,7 @@ func New(a *agent.Agent, cfg ServerConfig) *Server {
 	}
 
 	m := metrics.NewMetrics()
-	hc := health.NewHealthCheck("v0.20.0")
+	hc := health.NewHealthCheck("v0.21.0")
 
 	// v0.18.0: WebSocket Hub
 	wsHandler := websocket.NewAgentHandler(a)
@@ -186,7 +186,7 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/api/v1/rag/index", s.handleRAGIndex)
 	mux.HandleFunc("/api/v1/rag/search", s.handleRAGSearch)
 	mux.HandleFunc("/api/v1/rag/stats", s.handleRAGStats)
-	mux.HandleFunc("/api/v1/rag/store", s.handleRAGStore) // v0.20.0: SQLite 持久化
+	mux.HandleFunc("/api/v1/rag/store", s.handleRAGStore) // v0.21.0: SQLite 持久化
 
 	// v0.15.0: Plugin API
 	mux.HandleFunc("/api/v1/plugins", s.handlePlugins)
@@ -205,6 +205,12 @@ func (s *Server) Start() error {
 	// v0.19.0: SOUL 模板
 	mux.HandleFunc("/api/v1/soul/templates", s.handleSoulTemplates)
 	mux.HandleFunc("/api/v1/soul/templates/", s.handleSoulTemplateByID)
+
+	// v0.21.0: 嵌入模型管理
+	mux.HandleFunc("/api/v1/embedders", s.handleEmbedderList)
+	mux.HandleFunc("/api/v1/embedders/register", s.handleEmbedderRegister)
+	mux.HandleFunc("/api/v1/embedders/switch", s.handleEmbedderSwitch)
+	mux.HandleFunc("/api/v1/embedders/", s.handleEmbedderRoutes)
 
 	// 根路由
 	mux.HandleFunc("/", s.handleRoot)
@@ -301,7 +307,7 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	}
 	s.sendJSON(w, http.StatusOK, map[string]interface{}{
 		"status":    "ok",
-		"version":   "v0.20.0",
+		"version":   "v0.21.0",
 		"timestamp": time.Now().Format(time.RFC3339),
 	})
 }
@@ -715,7 +721,7 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		"uptime":         uptime.String(),
 		"start_time":     stats.StartTime.Format(time.RFC3339),
 		"last_request":   stats.LastReqTime.Format(time.RFC3339),
-		"version":        "v0.20.0",
+		"version":        "v0.21.0",
 	})
 }
 
@@ -777,7 +783,7 @@ func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
 
 	s.sendJSON(w, http.StatusOK, map[string]interface{}{
 		"name":     "LuckyHarness API",
-		"version":  "v0.20.0",
+		"version":  "v0.21.0",
 		"endpoints": []string{
 			"POST /api/v1/chat       — 流式聊天 (SSE)",
 			"POST /api/v1/chat/sync  — 同步聊天",
@@ -1545,7 +1551,7 @@ type fcResponse struct {
 	State      string        `json:"state"`
 }
 
-// --- v0.20.0: RAG 持久化存储 API ---
+// --- v0.21.0: RAG 持久化存储 API ---
 
 // handleRAGStore 管理 RAG 向量存储后端
 func (s *Server) handleRAGStore(w http.ResponseWriter, r *http.Request) {
@@ -1608,7 +1614,7 @@ func (s *Server) handleRAGStore(w http.ResponseWriter, r *http.Request) {
 		// 迁移逻辑由 Agent 层处理
 		s.sendJSON(w, http.StatusOK, map[string]interface{}{
 			"message": "migration to SQLite requires restart with SQLite backend enabled",
-			"hint":    "SQLite backend is enabled by default in v0.20.0+",
+			"hint":    "SQLite backend is enabled by default in v0.21.0+",
 		})
 
 	default:

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -77,8 +77,8 @@ func TestHandleHealth(t *testing.T) {
 	if resp["status"] != "ok" {
 		t.Errorf("expected ok, got %v", resp["status"])
 	}
-	if resp["version"] != "v0.20.0" {
-		t.Errorf("expected v0.20.0, got %v", resp["version"])
+	if resp["version"] != "v0.21.0" {
+		t.Errorf("expected v0.21.0, got %v", resp["version"])
 	}
 }
 
@@ -247,8 +247,8 @@ func TestHandleStats(t *testing.T) {
 
 	var resp map[string]interface{}
 	json.NewDecoder(w.Body).Decode(&resp)
-	if resp["version"] != "v0.20.0" {
-		t.Errorf("expected v0.20.0, got %v", resp["version"])
+	if resp["version"] != "v0.21.0" {
+		t.Errorf("expected v0.21.0, got %v", resp["version"])
 	}
 }
 


### PR DESCRIPTION
## v0.21.0 嵌入模型管理系统

统一的嵌入模型管理，支持多 Provider 注册、切换和缓存。

### 新增
- internal/embedder/ — Embedder 接口 + Registry + LRU 缓存 + OpenAI/Ollama Provider
- API: GET/POST /api/v1/embedders, GET /embedders/{id}, POST /embedders/{id}/test
- REPL: /embedder list/switch/test
- RAG 集成: EmbeddingProvider → embedder.Embedder 类型别名

### 测试
- 26 embedder 包测试 + 10 API handler 测试
- 全量 567 测试通过