### PR TITLE
fix: data race in collab delegate manager

### DIFF
--- a/internal/collab/collab_test.go
+++ b/internal/collab/collab_test.go
@@ -3,6 +3,7 @@ package collab
 import (
 	"context"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -238,9 +239,9 @@ func TestDelegateManagerParallel(t *testing.T) {
 	_ = r.Register(&AgentProfile{ID: "agent-2", Name: "Agent 2"})
 	_ = r.Register(&AgentProfile{ID: "agent-3", Name: "Agent 3"})
 
-	callCount := 0
+	var callCount int64 // 使用 int64 以便原子操作
 	handler := TaskHandlerFunc(func(ctx context.Context, task *SubTask) (string, error) {
-		callCount++
+		atomic.AddInt64(&callCount, 1) // 原子递增，避免 data race
 		return "result_from_" + task.AgentID, nil
 	})
 
@@ -264,7 +265,7 @@ func TestDelegateManagerParallel(t *testing.T) {
 	}
 
 	// 所有 agent 都应该被调用
-	if callCount != 3 {
+	if atomic.LoadInt64(&callCount) != 3 {
 		t.Errorf("call count: got %d, want 3", callCount)
 	}
 }

--- a/internal/collab/delegate.go
+++ b/internal/collab/delegate.go
@@ -149,8 +149,23 @@ func (dm *DelegateManager) GetTask(taskID string) (*CollabTask, bool) {
 	if !ok {
 		return nil, false
 	}
-	// 返回副本
+	// 深拷贝，避免 data race
 	cp := *t
+	// 拷贝 SubTasks 切片
+	if t.SubTasks != nil {
+		cp.SubTasks = make([]*SubTask, len(t.SubTasks))
+		for i, sub := range t.SubTasks {
+			subCopy := *sub
+			cp.SubTasks[i] = &subCopy
+		}
+	}
+	// 拷贝 Metadata map
+	if t.Metadata != nil {
+		cp.Metadata = make(map[string]string, len(t.Metadata))
+		for k, v := range t.Metadata {
+			cp.Metadata[k] = v
+		}
+	}
 	return &cp, true
 }
 
@@ -161,7 +176,23 @@ func (dm *DelegateManager) ListTasks() []*CollabTask {
 
 	result := make([]*CollabTask, 0, len(dm.tasks))
 	for _, t := range dm.tasks {
+		// 深拷贝，避免 data race
 		cp := *t
+		// 拷贝 SubTasks 切片
+		if t.SubTasks != nil {
+			cp.SubTasks = make([]*SubTask, len(t.SubTasks))
+			for i, sub := range t.SubTasks {
+				subCopy := *sub
+				cp.SubTasks[i] = &subCopy
+			}
+		}
+		// 拷贝 Metadata map
+		if t.Metadata != nil {
+			cp.Metadata = make(map[string]string, len(t.Metadata))
+			for k, v := range t.Metadata {
+				cp.Metadata[k] = v
+			}
+		}
 		result = append(result, &cp)
 	}
 	return result

--- a/internal/server/collab_handlers.go
+++ b/internal/server/collab_handlers.go
@@ -165,9 +165,12 @@ func (s *Server) handleAgentsDelegate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// 使用 GetTask 获取深拷贝，避免 data race（后台 goroutine 正在修改 task）
+	taskCopy, _ := s.delegateManager.GetTask(task.ID)
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
-	json.NewEncoder(w).Encode(task)
+	json.NewEncoder(w).Encode(taskCopy)
 }
 
 // handleAgentsTask 获取任务状态


### PR DESCRIPTION
## 修复内容

修复 CI 中检测到的 data race 问题：

### 1. TestDelegateManagerParallel
- 使用  替代普通 
- 并行执行时多个 goroutine 同时写入计数器触发 race

### 2. GetTask / ListTasks
- 原实现只做浅拷贝， 切片和  map 指向同一底层数据
- 后台  goroutine 修改时，API 返回的副本也被修改
- 改为深拷贝：逐个复制 SubTask 和 Metadata

### 3. handleAgentsDelegate
-  返回后立即 JSON 编码，但后台 goroutine 正在修改 task
- 改用  获取深拷贝后再编码

## 测试

```bash
go test -race ./...
```

所有测试通过，无 race 检测。

## 关联

Fixes CI failure in runs 24658647826, 24658636012, etc.