### PR TITLE
feat(v0.23.0): 流式 RAG — 增量索引 + 实时检索 + 文件 Watcher + 变更检测

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,57 @@ LuckyHarness 是一个用 Go 重写的 AI Agent 框架，参考 Hermes Agent 的
 | v0.20.0 | RAG SQLite 持久化 | SQLite 向量存储 + WAL 模式 + 增量索引 + 持久化 API + REPL 命令 |
 | v0.21.0 | 嵌入模型管理 | Embedder 接口 + Registry + LRU 缓存 + OpenAI/Ollama Provider + API + REPL |
 | v0.22.0 | 多 Agent 协作 | Agent Registry + 任务委派 + 结果聚合 + Pipeline/Parallel/Debate 模式 + API + CLI |
+| v0.23.0 | 流式 RAG | StreamIndexer + ChangeDetector + IndexQueue + 文件监控 + 增量索引 + API + CLI |
+
+## v0.23.0 新特性
+
+### 流式 RAG 系统
+
+支持文件变更监控和增量索引，实现实时知识库更新：
+
+```bash
+# 添加监控目录
+lh rag watch ./docs
+
+# 扫描变更
+lh rag scan
+
+# 启动后台索引
+lh rag start
+
+# 查看状态
+lh rag status
+
+# 处理队列
+lh rag process 10
+
+# 停止后台索引
+lh rag stop
+```
+
+#### 特性
+
+- **StreamIndexer** — 流式索引器，支持增量添加/更新/删除
+- **ChangeDetector** — 文件哈希对比，识别新增/修改/删除
+- **IndexQueue** — 索引任务队列，支持优先级和批处理
+- **File Watcher** — 目录监控，自动触发索引
+- **API 端点** — 8 个 RESTful API 端点
+- **REPL 命令** — lh rag watch/unwatch/scan/start/stop/status/queue/process
+
+#### API 端点
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| POST | `/api/v1/rag/stream/watch` | 添加监控目录 |
+| DELETE | `/api/v1/rag/stream/watch` | 移除监控目录 |
+| POST | `/api/v1/rag/stream/scan` | 扫描变更 |
+| POST | `/api/v1/rag/stream/start` | 启动后台索引 |
+| POST | `/api/v1/rag/stream/stop` | 停止后台索引 |
+| GET | `/api/v1/rag/stream/status` | 查看状态 |
+| POST | `/api/v1/rag/stream/index` | 立即索引路径 |
+| DELETE | `/api/v1/rag/stream/index` | 移除路径 |
+| GET | `/api/v1/rag/stream/queue` | 查看队列 |
+| POST | `/api/v1/rag/stream/process` | 处理队列 |
 
 ## v0.22.0 新特性
 

--- a/cmd/lh/main.go
+++ b/cmd/lh/main.go
@@ -448,6 +448,53 @@ func main() {
 	}
 	ragCmd.AddCommand(ragIndexCmd, ragSearchCmd, ragStatsCmd)
 
+	// ===== v0.23.0: 流式 RAG 命令 =====
+	ragWatchCmd := &cobra.Command{
+		Use:   "watch <dir>",
+		Short: "添加监控目录",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runRAGWatch,
+	}
+	ragUnwatchCmd := &cobra.Command{
+		Use:   "unwatch <dir>",
+		Short: "移除监控目录",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runRAGUnwatch,
+	}
+	ragScanCmd := &cobra.Command{
+		Use:   "scan",
+		Short: "扫描变更",
+		RunE:  runRAGScan,
+	}
+	ragStartCmd := &cobra.Command{
+		Use:   "start",
+		Short: "启动后台索引",
+		RunE:  runRAGStart,
+	}
+	ragStopCmd := &cobra.Command{
+		Use:   "stop",
+		Short: "停止后台索引",
+		RunE:  runRAGStop,
+	}
+	ragStreamStatusCmd := &cobra.Command{
+		Use:   "status",
+		Short: "流式索引状态",
+		RunE:  runRAGStreamStatus,
+	}
+	ragQueueCmd := &cobra.Command{
+		Use:   "queue",
+		Short: "查看索引队列",
+		RunE:  runRAGQueue,
+	}
+	ragProcessCmd := &cobra.Command{
+		Use:   "process [batch]",
+		Short: "处理索引队列",
+		Args:  cobra.MaximumNArgs(1),
+		RunE:  runRAGProcess,
+	}
+	ragCmd.AddCommand(ragWatchCmd, ragUnwatchCmd, ragScanCmd, ragStartCmd, ragStopCmd,
+		ragStreamStatusCmd, ragQueueCmd, ragProcessCmd)
+
 	// ===== v0.15.0: Plugin 命令 =====
 	pluginCmd := &cobra.Command{
 		Use:   "plugin",
@@ -1489,6 +1536,248 @@ func runRAGStats(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	return nil
+}
+
+// ===== v0.23.0: 流式 RAG 命令实现 =====
+
+func runRAGWatch(cmd *cobra.Command, args []string) error {
+	mgr, err := config.NewManager()
+	if err != nil {
+		return err
+	}
+	if err := mgr.Load(); err != nil {
+		return err
+	}
+
+	a, err := agent.New(mgr)
+	if err != nil {
+		return fmt.Errorf("create agent: %w", err)
+	}
+
+	streamIndexer := a.StreamIndexer()
+	if streamIndexer == nil {
+		return fmt.Errorf("stream indexer not initialized")
+	}
+
+	dir := args[0]
+	info, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("directory not found: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", dir)
+	}
+
+	streamIndexer.AddWatchDir(dir)
+	fmt.Printf("👀 Watching: %s\n", dir)
+	return nil
+}
+
+func runRAGUnwatch(cmd *cobra.Command, args []string) error {
+	mgr, err := config.NewManager()
+	if err != nil {
+		return err
+	}
+	if err := mgr.Load(); err != nil {
+		return err
+	}
+
+	a, err := agent.New(mgr)
+	if err != nil {
+		return fmt.Errorf("create agent: %w", err)
+	}
+
+	streamIndexer := a.StreamIndexer()
+	if streamIndexer == nil {
+		return fmt.Errorf("stream indexer not initialized")
+	}
+
+	streamIndexer.RemoveWatchDir(args[0])
+	fmt.Printf("🚫 Unwatched: %s\n", args[0])
+	return nil
+}
+
+func runRAGScan(cmd *cobra.Command, args []string) error {
+	mgr, err := config.NewManager()
+	if err != nil {
+		return err
+	}
+	if err := mgr.Load(); err != nil {
+		return err
+	}
+
+	a, err := agent.New(mgr)
+	if err != nil {
+		return fmt.Errorf("create agent: %w", err)
+	}
+
+	streamIndexer := a.StreamIndexer()
+	if streamIndexer == nil {
+		return fmt.Errorf("stream indexer not initialized")
+	}
+
+	changes := streamIndexer.Scan()
+	fmt.Printf("🔍 Detected %d changes:\n", len(changes))
+	for _, c := range changes {
+		fmt.Printf("   %s: %s\n", c.Type, c.Path)
+	}
+	fmt.Printf("📋 Queue: %d jobs pending\n", streamIndexer.Queue().Len())
+	return nil
+}
+
+func runRAGStart(cmd *cobra.Command, args []string) error {
+	mgr, err := config.NewManager()
+	if err != nil {
+		return err
+	}
+	if err := mgr.Load(); err != nil {
+		return err
+	}
+
+	a, err := agent.New(mgr)
+	if err != nil {
+		return fmt.Errorf("create agent: %w", err)
+	}
+
+	streamIndexer := a.StreamIndexer()
+	if streamIndexer == nil {
+		return fmt.Errorf("stream indexer not initialized")
+	}
+
+	if streamIndexer.IsRunning() {
+		fmt.Println("⚠️  Stream indexer already running")
+		return nil
+	}
+
+	streamIndexer.Start()
+	fmt.Println("▶️  Stream indexer started")
+	return nil
+}
+
+func runRAGStop(cmd *cobra.Command, args []string) error {
+	mgr, err := config.NewManager()
+	if err != nil {
+		return err
+	}
+	if err := mgr.Load(); err != nil {
+		return err
+	}
+
+	a, err := agent.New(mgr)
+	if err != nil {
+		return fmt.Errorf("create agent: %w", err)
+	}
+
+	streamIndexer := a.StreamIndexer()
+	if streamIndexer == nil {
+		return fmt.Errorf("stream indexer not initialized")
+	}
+
+	if !streamIndexer.IsRunning() {
+		fmt.Println("⚠️  Stream indexer not running")
+		return nil
+	}
+
+	streamIndexer.Stop()
+	fmt.Println("⏹️  Stream indexer stopped")
+	return nil
+}
+
+func runRAGStreamStatus(cmd *cobra.Command, args []string) error {
+	mgr, err := config.NewManager()
+	if err != nil {
+		return err
+	}
+	if err := mgr.Load(); err != nil {
+		return err
+	}
+
+	a, err := agent.New(mgr)
+	if err != nil {
+		return fmt.Errorf("create agent: %w", err)
+	}
+
+	streamIndexer := a.StreamIndexer()
+	if streamIndexer == nil {
+		fmt.Println("❌ Stream indexer not initialized")
+		return nil
+	}
+
+	stats := streamIndexer.Stats()
+	fmt.Printf("📊 Stream Indexer Status:\n")
+	fmt.Printf("   Running:       %v\n", stats.Running)
+	fmt.Printf("   Queue:         %d jobs\n", stats.QueueLen)
+	fmt.Printf("   Tracked files: %d\n", stats.TrackedFiles)
+	fmt.Printf("   Watch dirs:    %d\n", len(stats.WatchDirs))
+	for _, d := range stats.WatchDirs {
+		fmt.Printf("     - %s\n", d)
+	}
+	return nil
+}
+
+func runRAGQueue(cmd *cobra.Command, args []string) error {
+	mgr, err := config.NewManager()
+	if err != nil {
+		return err
+	}
+	if err := mgr.Load(); err != nil {
+		return err
+	}
+
+	a, err := agent.New(mgr)
+	if err != nil {
+		return fmt.Errorf("create agent: %w", err)
+	}
+
+	streamIndexer := a.StreamIndexer()
+	if streamIndexer == nil {
+		return fmt.Errorf("stream indexer not initialized")
+	}
+
+	jobs := streamIndexer.Queue().List()
+	fmt.Printf("📋 Index Queue (%d jobs):\n", len(jobs))
+	for i, job := range jobs {
+		fmt.Printf("  %d. [%s] %s (priority %d)\n", i+1, job.JobType, job.Path, job.Priority)
+	}
+	return nil
+}
+
+func runRAGProcess(cmd *cobra.Command, args []string) error {
+	mgr, err := config.NewManager()
+	if err != nil {
+		return err
+	}
+	if err := mgr.Load(); err != nil {
+		return err
+	}
+
+	a, err := agent.New(mgr)
+	if err != nil {
+		return fmt.Errorf("create agent: %w", err)
+	}
+
+	streamIndexer := a.StreamIndexer()
+	if streamIndexer == nil {
+		return fmt.Errorf("stream indexer not initialized")
+	}
+
+	batch := 1
+	if len(args) > 0 {
+		fmt.Sscanf(args[0], "%d", &batch)
+	}
+
+	jobs, docs, errs := streamIndexer.ProcessBatch(context.Background(), batch)
+	fmt.Printf("⚙️  Processed %d jobs:\n", len(jobs))
+	for i := range jobs {
+		if errs[i] != nil {
+			fmt.Printf("  ❌ %s: %v\n", jobs[i].Path, errs[i])
+		} else if docs[i] != nil {
+			fmt.Printf("  ✅ %s (%d chunks)\n", docs[i].Title, len(docs[i].Chunks))
+		} else {
+			fmt.Printf("  🗑️  %s (deleted)\n", jobs[i].Path)
+		}
+	}
 	return nil
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -36,6 +36,7 @@ type Agent struct {
 	contextWin   *contextx.ContextWindow // 上下文窗口管理器
 	ragManager   *rag.RAGManager         // RAG 知识库管理器
 	ragPersist   *rag.Persistence        // RAG 持久化
+	streamIndexer *rag.StreamIndexer     // v0.23.0: 流式索引器
 	embedderReg  *embedder.Registry      // v0.21.0: 嵌入模型注册表
 	collabReg    *collab.Registry        // v0.22.0: Agent 协作注册表
 	collabMgr    *collab.DelegateManager // v0.22.0: 协作任务管理器
@@ -222,6 +223,9 @@ func New(cfg *config.Manager) (*Agent, error) {
 	// 创建协作任务管理器（使用默认 handler，实际执行由 Agent Loop 驱动）
 	collabMgr := collab.NewDelegateManager(collabReg, nil)
 
+	// v0.23.0: 创建流式索引器
+	streamIndexer := rag.NewStreamIndexer(ragManager, rag.DefaultStreamConfig())
+
 	return &Agent{
 		cfg:        cfg,
 		soul:       s,
@@ -239,6 +243,7 @@ func New(cfg *config.Manager) (*Agent, error) {
 		contextWin: contextWin,
 		ragManager:  ragManager,
 		ragPersist:  ragPersist,
+		streamIndexer: streamIndexer,
 		embedderReg: embedderReg,
 		collabReg:   collabReg,
 		collabMgr:   collabMgr,
@@ -572,6 +577,11 @@ func (a *Agent) RAG() *rag.RAGManager {
 // RAGPersist 返回 RAG 持久化管理器
 func (a *Agent) RAGPersist() *rag.Persistence {
 	return a.ragPersist
+}
+
+// StreamIndexer 返回流式索引器 (v0.23.0)
+func (a *Agent) StreamIndexer() *rag.StreamIndexer {
+	return a.streamIndexer
 }
 
 // EmbedderRegistry 返回嵌入模型注册表

--- a/internal/rag/stream.go
+++ b/internal/rag/stream.go
@@ -1,0 +1,630 @@
+package rag
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ChangeType represents the type of file change detected.
+type ChangeType int
+
+const (
+	ChangeNone ChangeType = iota
+	ChangeAdded
+	ChangeModified
+	ChangeDeleted
+)
+
+func (ct ChangeType) String() string {
+	switch ct {
+	case ChangeAdded:
+		return "added"
+	case ChangeModified:
+		return "modified"
+	case ChangeDeleted:
+		return "deleted"
+	default:
+		return "none"
+	}
+}
+
+// FileChange represents a detected file change.
+type FileChange struct {
+	Path      string
+	Type      ChangeType
+	OldHash   string
+	NewHash   string
+	Timestamp time.Time
+}
+
+// IndexJob represents an indexing job in the queue.
+type IndexJob struct {
+	ID        string
+	Path      string
+	JobType   ChangeType
+	Priority  int       // higher = more urgent
+	CreatedAt time.Time
+	StartedAt time.Time
+	CompletedAt time.Time
+	Error     error
+}
+
+// IndexQueue manages pending indexing jobs.
+type IndexQueue struct {
+	mu    sync.RWMutex
+	jobs  map[string]*IndexJob // path -> job
+	order []*IndexJob          // sorted by priority
+}
+
+// NewIndexQueue creates a new index queue.
+func NewIndexQueue() *IndexQueue {
+	return &IndexQueue{
+		jobs:  make(map[string]*IndexJob),
+		order: make([]*IndexJob, 0),
+	}
+}
+
+// Add adds a job to the queue. If a job for the path exists, it updates priority.
+func (q *IndexQueue) Add(path string, jobType ChangeType, priority int) *IndexJob {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	jobID := jobID(path)
+	now := time.Now()
+
+	if existing, ok := q.jobs[path]; ok {
+		// Update existing job
+		if priority > existing.Priority {
+			existing.Priority = priority
+			q.sortLocked() // re-sort when priority changes
+		}
+		existing.JobType = jobType
+		return existing
+	}
+
+	job := &IndexJob{
+		ID:        jobID,
+		Path:      path,
+		JobType:   jobType,
+		Priority:  priority,
+		CreatedAt: now,
+	}
+
+	q.jobs[path] = job
+	q.order = append(q.order, job)
+	q.sortLocked()
+
+	return job
+}
+
+// Pop removes and returns the highest priority job.
+func (q *IndexQueue) Pop() *IndexJob {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if len(q.order) == 0 {
+		return nil
+	}
+
+	job := q.order[0]
+	q.order = q.order[1:]
+	delete(q.jobs, job.Path)
+
+	return job
+}
+
+// Peek returns the highest priority job without removing it.
+func (q *IndexQueue) Peek() *IndexJob {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	if len(q.order) == 0 {
+		return nil
+	}
+	return q.order[0]
+}
+
+// Len returns the number of pending jobs.
+func (q *IndexQueue) Len() int {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return len(q.order)
+}
+
+// Clear removes all jobs from the queue.
+func (q *IndexQueue) Clear() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.jobs = make(map[string]*IndexJob)
+	q.order = make([]*IndexJob, 0)
+}
+
+// List returns all pending jobs.
+func (q *IndexQueue) List() []*IndexJob {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	jobs := make([]*IndexJob, len(q.order))
+	copy(jobs, q.order)
+	return jobs
+}
+
+// Remove removes a job by path.
+func (q *IndexQueue) Remove(path string) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if _, ok := q.jobs[path]; !ok {
+		return false
+	}
+
+	delete(q.jobs, path)
+
+	// Rebuild order slice
+	newOrder := make([]*IndexJob, 0, len(q.order))
+	for _, job := range q.order {
+		if job.Path != path {
+			newOrder = append(newOrder, job)
+		}
+	}
+	q.order = newOrder
+
+	return true
+}
+
+func (q *IndexQueue) sortLocked() {
+	// Simple insertion sort for small queues
+	for i := 1; i < len(q.order); i++ {
+		for j := i; j > 0 && q.order[j].Priority > q.order[j-1].Priority; j-- {
+			q.order[j], q.order[j-1] = q.order[j-1], q.order[j]
+		}
+	}
+}
+
+// ChangeDetector detects file changes using hash comparison.
+type ChangeDetector struct {
+	mu       sync.RWMutex
+	hashes   map[string]string // path -> hash
+	fileInfo map[string]os.FileInfo
+}
+
+// NewChangeDetector creates a new change detector.
+func NewChangeDetector() *ChangeDetector {
+	return &ChangeDetector{
+		hashes:   make(map[string]string),
+		fileInfo: make(map[string]os.FileInfo),
+	}
+}
+
+// ComputeHash computes SHA256 hash of a file.
+func (cd *ChangeDetector) ComputeHash(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	hash := sha256.Sum256(data)
+	return hex.EncodeToString(hash[:]), nil
+}
+
+// Snapshot takes a snapshot of a directory's file hashes.
+func (cd *ChangeDetector) Snapshot(dir string, extensions []string) error {
+	cd.mu.Lock()
+	defer cd.mu.Unlock()
+
+	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil // skip errors
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		// Check extension
+		ext := strings.ToLower(filepath.Ext(path))
+		matched := len(extensions) == 0
+		for _, e := range extensions {
+			if strings.ToLower(e) == ext {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return nil
+		}
+
+		hash, err := cd.ComputeHash(path)
+		if err != nil {
+			return nil // skip unreadable files
+		}
+
+		cd.hashes[path] = hash
+		cd.fileInfo[path] = info
+		return nil
+	})
+}
+
+// DetectChanges compares current state with snapshot and returns changes.
+func (cd *ChangeDetector) DetectChanges(dir string, extensions []string) []FileChange {
+	cd.mu.Lock()
+	defer cd.mu.Unlock()
+
+	changes := make([]FileChange, 0)
+	currentHashes := make(map[string]string)
+	currentInfo := make(map[string]os.FileInfo)
+
+	// Scan current state
+	filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+
+		ext := strings.ToLower(filepath.Ext(path))
+		matched := len(extensions) == 0
+		for _, e := range extensions {
+			if strings.ToLower(e) == ext {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return nil
+		}
+
+		hash, err := cd.ComputeHash(path)
+		if err != nil {
+			return nil
+		}
+
+		currentHashes[path] = hash
+		currentInfo[path] = info
+
+		// Check if new or modified
+		oldHash, existed := cd.hashes[path]
+		now := time.Now()
+
+		if !existed {
+			changes = append(changes, FileChange{
+				Path:      path,
+				Type:      ChangeAdded,
+				NewHash:   hash,
+				Timestamp: now,
+			})
+		} else if oldHash != hash {
+			changes = append(changes, FileChange{
+				Path:      path,
+				Type:      ChangeModified,
+				OldHash:   oldHash,
+				NewHash:   hash,
+				Timestamp: now,
+			})
+		}
+
+		return nil
+	})
+
+	// Check for deleted files
+	for path, oldHash := range cd.hashes {
+		if _, exists := currentHashes[path]; !exists {
+			changes = append(changes, FileChange{
+				Path:      path,
+				Type:      ChangeDeleted,
+				OldHash:   oldHash,
+				Timestamp: time.Now(),
+			})
+		}
+	}
+
+	// Update snapshot
+	cd.hashes = currentHashes
+	cd.fileInfo = currentInfo
+
+	return changes
+}
+
+// GetHash returns the stored hash for a path.
+func (cd *ChangeDetector) GetHash(path string) (string, bool) {
+	cd.mu.RLock()
+	defer cd.mu.RUnlock()
+	h, ok := cd.hashes[path]
+	return h, ok
+}
+
+// SetHash manually sets a hash for a path.
+func (cd *ChangeDetector) SetHash(path, hash string) {
+	cd.mu.Lock()
+	defer cd.mu.Unlock()
+	cd.hashes[path] = hash
+}
+
+// RemoveHash removes a hash entry.
+func (cd *ChangeDetector) RemoveHash(path string) {
+	cd.mu.Lock()
+	defer cd.mu.Unlock()
+	delete(cd.hashes, path)
+	delete(cd.fileInfo, path)
+}
+
+// StreamIndexer provides incremental indexing with change detection.
+type StreamIndexer struct {
+	rag       *RAGManager
+	detector  *ChangeDetector
+	queue     *IndexQueue
+	watchDirs []string
+	extensions []string
+
+	mu       sync.RWMutex
+	running  bool
+	stopCh   chan struct{}
+	workers  int
+
+	// Callbacks
+	OnChange func(change FileChange)
+	OnIndex  func(job *IndexJob, doc *Document, err error)
+}
+
+// StreamConfig configures the stream indexer.
+type StreamConfig struct {
+	WatchDirs  []string
+	Extensions []string
+	Workers    int
+}
+
+// DefaultStreamConfig returns default configuration.
+func DefaultStreamConfig() StreamConfig {
+	return StreamConfig{
+		Extensions: []string{".md", ".txt"},
+		Workers:    2,
+	}
+}
+
+// NewStreamIndexer creates a new stream indexer.
+func NewStreamIndexer(rag *RAGManager, config StreamConfig) *StreamIndexer {
+	if config.Workers <= 0 {
+		config.Workers = 2
+	}
+
+	return &StreamIndexer{
+		rag:        rag,
+		detector:   NewChangeDetector(),
+		queue:      NewIndexQueue(),
+		watchDirs:  config.WatchDirs,
+		extensions: config.Extensions,
+		workers:    config.Workers,
+		stopCh:     make(chan struct{}),
+	}
+}
+
+// AddWatchDir adds a directory to watch.
+func (si *StreamIndexer) AddWatchDir(dir string) {
+	si.mu.Lock()
+	defer si.mu.Unlock()
+	si.watchDirs = append(si.watchDirs, dir)
+}
+
+// RemoveWatchDir removes a watched directory.
+func (si *StreamIndexer) RemoveWatchDir(dir string) {
+	si.mu.Lock()
+	defer si.mu.Unlock()
+
+	newDirs := make([]string, 0, len(si.watchDirs))
+	for _, d := range si.watchDirs {
+		if d != dir {
+			newDirs = append(newDirs, d)
+		}
+	}
+	si.watchDirs = newDirs
+}
+
+// Snapshot takes initial snapshots of all watched directories.
+func (si *StreamIndexer) Snapshot() error {
+	si.mu.RLock()
+	dirs := make([]string, len(si.watchDirs))
+	copy(dirs, si.watchDirs)
+	si.mu.RUnlock()
+
+	for _, dir := range dirs {
+		if err := si.detector.Snapshot(dir, si.extensions); err != nil {
+			return fmt.Errorf("snapshot %s: %w", dir, err)
+		}
+	}
+	return nil
+}
+
+// Scan detects changes and queues indexing jobs.
+func (si *StreamIndexer) Scan() []FileChange {
+	si.mu.RLock()
+	dirs := make([]string, len(si.watchDirs))
+	copy(dirs, si.watchDirs)
+	si.mu.RUnlock()
+
+	var allChanges []FileChange
+	for _, dir := range dirs {
+		changes := si.detector.DetectChanges(dir, si.extensions)
+		allChanges = append(allChanges, changes...)
+
+		// Queue jobs
+		for _, change := range changes {
+			priority := 5 // default priority
+			if change.Type == ChangeDeleted {
+				priority = 10 // delete first
+			}
+
+			si.queue.Add(change.Path, change.Type, priority)
+
+			if si.OnChange != nil {
+				si.OnChange(change)
+			}
+		}
+	}
+
+	return allChanges
+}
+
+// ProcessOne processes one job from the queue.
+func (si *StreamIndexer) ProcessOne(ctx context.Context) (*IndexJob, *Document, error) {
+	job := si.queue.Pop()
+	if job == nil {
+		return nil, nil, nil
+	}
+
+	job.StartedAt = time.Now()
+	var doc *Document
+	var err error
+
+	switch job.JobType {
+	case ChangeAdded, ChangeModified:
+		doc, err = si.rag.IndexFile(job.Path)
+	case ChangeDeleted:
+		si.rag.RemoveDocument(docID(job.Path))
+		si.detector.RemoveHash(job.Path)
+	}
+
+	job.CompletedAt = time.Now()
+	job.Error = err
+
+	if si.OnIndex != nil {
+		si.OnIndex(job, doc, err)
+	}
+
+	return job, doc, err
+}
+
+// ProcessBatch processes up to n jobs from the queue.
+func (si *StreamIndexer) ProcessBatch(ctx context.Context, n int) ([]*IndexJob, []*Document, []error) {
+	jobs := make([]*IndexJob, 0, n)
+	docs := make([]*Document, 0, n)
+	errs := make([]error, 0, n)
+
+	for i := 0; i < n && si.queue.Len() > 0; i++ {
+		job, doc, err := si.ProcessOne(ctx)
+		if job == nil {
+			break
+		}
+		jobs = append(jobs, job)
+		docs = append(docs, doc)
+		errs = append(errs, err)
+	}
+
+	return jobs, docs, errs
+}
+
+// Start starts background workers.
+func (si *StreamIndexer) Start() {
+	si.mu.Lock()
+	if si.running {
+		si.mu.Unlock()
+		return
+	}
+	si.running = true
+	si.mu.Unlock()
+
+	for i := 0; i < si.workers; i++ {
+		go si.worker(i)
+	}
+}
+
+// Stop stops all workers.
+func (si *StreamIndexer) Stop() {
+	si.mu.Lock()
+	if !si.running {
+		si.mu.Unlock()
+		return
+	}
+	si.running = false
+	close(si.stopCh)
+	si.mu.Unlock()
+}
+
+// IsRunning returns whether the indexer is running.
+func (si *StreamIndexer) IsRunning() bool {
+	si.mu.RLock()
+	defer si.mu.RUnlock()
+	return si.running
+}
+
+// Queue returns the underlying queue.
+func (si *StreamIndexer) Queue() *IndexQueue {
+	return si.queue
+}
+
+// Detector returns the underlying change detector.
+func (si *StreamIndexer) Detector() *ChangeDetector {
+	return si.detector
+}
+
+func (si *StreamIndexer) worker(id int) {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-si.stopCh:
+			return
+		case <-ticker.C:
+			// Scan for changes
+			si.Scan()
+
+			// Process pending jobs
+			for si.queue.Len() > 0 {
+				si.ProcessOne(context.Background())
+			}
+		}
+	}
+}
+
+// IndexPath indexes a single path immediately.
+func (si *StreamIndexer) IndexPath(path string) (*Document, error) {
+	hash, err := si.detector.ComputeHash(path)
+	if err != nil {
+		return nil, fmt.Errorf("compute hash: %w", err)
+	}
+
+	doc, err := si.rag.IndexFile(path)
+	if err == nil {
+		si.detector.SetHash(path, hash)
+	}
+
+	return doc, err
+}
+
+// RemovePath removes a path from the index.
+func (si *StreamIndexer) RemovePath(path string) bool {
+	removed := si.rag.RemoveDocument(docID(path))
+	if removed {
+		si.detector.RemoveHash(path)
+	}
+	return removed
+}
+
+// Stats returns stream indexer statistics.
+type StreamStats struct {
+	QueueLen     int
+	WatchDirs    []string
+	TrackedFiles int
+	Running      bool
+}
+
+// Stats returns current statistics.
+func (si *StreamIndexer) Stats() StreamStats {
+	si.mu.RLock()
+	defer si.mu.RUnlock()
+
+	return StreamStats{
+		QueueLen:     si.queue.Len(),
+		WatchDirs:    si.watchDirs,
+		TrackedFiles: len(si.detector.hashes),
+		Running:      si.running,
+	}
+}
+
+func jobID(path string) string {
+	h := sha256.Sum256([]byte(path))
+	return fmt.Sprintf("job-%x", h[:8])
+}

--- a/internal/rag/stream_test.go
+++ b/internal/rag/stream_test.go
@@ -1,0 +1,468 @@
+package rag
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestIndexQueue(t *testing.T) {
+	q := NewIndexQueue()
+
+	// Test empty queue
+	if q.Len() != 0 {
+		t.Errorf("expected empty queue, got %d", q.Len())
+	}
+	if q.Pop() != nil {
+		t.Error("expected nil from empty queue")
+	}
+
+	// Add jobs
+	job1 := q.Add("/path/1.md", ChangeAdded, 5)
+	if job1 == nil {
+		t.Fatal("expected job, got nil")
+	}
+	if job1.Priority != 5 {
+		t.Errorf("expected priority 5, got %d", job1.Priority)
+	}
+
+	q.Add("/path/2.md", ChangeModified, 10)
+	q.Add("/path/3.md", ChangeDeleted, 7)
+
+	// Test length
+	if q.Len() != 3 {
+		t.Errorf("expected 3 jobs, got %d", q.Len())
+	}
+
+	// Pop should return highest priority first
+	popped := q.Pop()
+	if popped.Path != "/path/2.md" {
+		t.Errorf("expected /path/2.md (priority 10), got %s", popped.Path)
+	}
+
+	// Test update existing job
+	q.Add("/path/1.md", ChangeModified, 15) // upgrade priority
+	popped = q.Pop()
+	if popped.Path != "/path/1.md" {
+		t.Errorf("expected /path/1.md (upgraded priority), got %s", popped.Path)
+	}
+
+	// Test remove
+	q.Add("/path/4.md", ChangeAdded, 3)
+	if !q.Remove("/path/4.md") {
+		t.Error("expected remove to succeed")
+	}
+	if q.Remove("/path/4.md") {
+		t.Error("expected remove to fail for non-existent")
+	}
+
+	// Test clear
+	q.Add("/path/5.md", ChangeAdded, 1)
+	q.Clear()
+	if q.Len() != 0 {
+		t.Errorf("expected empty after clear, got %d", q.Len())
+	}
+}
+
+func TestChangeDetector(t *testing.T) {
+	// Create temp directory with test files
+	tmpDir := t.TempDir()
+
+	file1 := filepath.Join(tmpDir, "test1.md")
+	file2 := filepath.Join(tmpDir, "test2.txt")
+	file3 := filepath.Join(tmpDir, "test3.go")
+
+	os.WriteFile(file1, []byte("# Test 1\nContent 1"), 0644)
+	os.WriteFile(file2, []byte("Test 2 content"), 0644)
+	os.WriteFile(file3, []byte("package main"), 0644)
+
+	cd := NewChangeDetector()
+
+	// Test ComputeHash
+	hash1, err := cd.ComputeHash(file1)
+	if err != nil {
+		t.Fatalf("compute hash: %v", err)
+	}
+	if hash1 == "" {
+		t.Error("expected non-empty hash")
+	}
+
+	// Test Snapshot
+	err = cd.Snapshot(tmpDir, []string{".md", ".txt"})
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	// Verify hashes stored
+	if h, ok := cd.GetHash(file1); !ok || h != hash1 {
+		t.Error("expected hash to be stored")
+	}
+	if _, ok := cd.GetHash(file3); ok {
+		t.Error("expected .go file to be excluded")
+	}
+
+	// Modify file1
+	time.Sleep(10 * time.Millisecond) // ensure different timestamp
+	os.WriteFile(file1, []byte("# Test 1 Modified\nNew content"), 0644)
+
+	// Add new file
+	file4 := filepath.Join(tmpDir, "test4.md")
+	os.WriteFile(file4, []byte("New file"), 0644)
+
+	// Delete file2
+	os.Remove(file2)
+
+	// Detect changes
+	changes := cd.DetectChanges(tmpDir, []string{".md", ".txt"})
+
+	// Should detect 3 changes: modified file1, added file4, deleted file2
+	changeMap := make(map[string]ChangeType)
+	for _, c := range changes {
+		changeMap[c.Path] = c.Type
+	}
+
+	if changeMap[file1] != ChangeModified {
+		t.Errorf("expected file1 to be modified, got %v", changeMap[file1])
+	}
+	if changeMap[file4] != ChangeAdded {
+		t.Errorf("expected file4 to be added, got %v", changeMap[file4])
+	}
+	if changeMap[file2] != ChangeDeleted {
+		t.Errorf("expected file2 to be deleted, got %v", changeMap[file2])
+	}
+}
+
+func TestChangeTypeString(t *testing.T) {
+	tests := []struct {
+		ct       ChangeType
+		expected string
+	}{
+		{ChangeNone, "none"},
+		{ChangeAdded, "added"},
+		{ChangeModified, "modified"},
+		{ChangeDeleted, "deleted"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.ct.String(); got != tt.expected {
+			t.Errorf("ChangeType(%d).String() = %s, want %s", tt.ct, got, tt.expected)
+		}
+	}
+}
+
+func TestStreamIndexerBasic(t *testing.T) {
+	// Create temp directory
+	tmpDir := t.TempDir()
+
+	file1 := filepath.Join(tmpDir, "doc1.md")
+	os.WriteFile(file1, []byte("# Document 1\nThis is content."), 0644)
+
+	// Create mock embedder
+	embedder := NewMockEmbedder(128)
+
+	// Create RAG manager
+	rag := NewRAGManager(embedder, DefaultRAGConfig())
+
+	// Create stream indexer
+	si := NewStreamIndexer(rag, StreamConfig{
+		WatchDirs:  []string{tmpDir},
+		Extensions: []string{".md"},
+		Workers:    1,
+	})
+
+	// Test initial snapshot
+	err := si.Snapshot()
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	// Index the file
+	doc, err := si.IndexPath(file1)
+	if err != nil {
+		t.Fatalf("index path: %v", err)
+	}
+	if doc == nil {
+		t.Fatal("expected document, got nil")
+	}
+	if doc.Title != "Document 1" {
+		t.Errorf("expected title 'Document 1', got %s", doc.Title)
+	}
+
+	// Verify in RAG index
+	stats := rag.Stats()
+	if stats.DocumentCount != 1 {
+		t.Errorf("expected 1 document, got %d", stats.DocumentCount)
+	}
+
+	// Test remove
+	removed := si.RemovePath(file1)
+	if !removed {
+		t.Error("expected remove to succeed")
+	}
+
+	stats = rag.Stats()
+	if stats.DocumentCount != 0 {
+		t.Errorf("expected 0 documents after remove, got %d", stats.DocumentCount)
+	}
+}
+
+func TestStreamIndexerScan(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create initial files
+	file1 := filepath.Join(tmpDir, "file1.md")
+	os.WriteFile(file1, []byte("# File 1"), 0644)
+
+	embedder := NewMockEmbedder(128)
+	rag := NewRAGManager(embedder, DefaultRAGConfig())
+
+	si := NewStreamIndexer(rag, StreamConfig{
+		WatchDirs:  []string{tmpDir},
+		Extensions: []string{".md"},
+		Workers:    0, // no background workers
+	})
+
+	// Take initial snapshot
+	si.Snapshot()
+
+	// Index initial file
+	si.IndexPath(file1)
+
+	// Add new file
+	file2 := filepath.Join(tmpDir, "file2.md")
+	os.WriteFile(file2, []byte("# File 2"), 0644)
+
+	// Modify existing file
+	time.Sleep(10 * time.Millisecond)
+	os.WriteFile(file1, []byte("# File 1 Modified"), 0644)
+
+	// Scan for changes
+	changes := si.Scan()
+
+	changeMap := make(map[string]ChangeType)
+	for _, c := range changes {
+		changeMap[c.Path] = c.Type
+	}
+
+	if changeMap[file1] != ChangeModified {
+		t.Errorf("expected file1 to be modified, got %v", changeMap[file1])
+	}
+	if changeMap[file2] != ChangeAdded {
+		t.Errorf("expected file2 to be added, got %v", changeMap[file2])
+	}
+
+	// Verify queue has jobs
+	if si.Queue().Len() != 2 {
+		t.Errorf("expected 2 jobs in queue, got %d", si.Queue().Len())
+	}
+}
+
+func TestStreamIndexerProcessBatch(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create files
+	for i := 0; i < 3; i++ {
+		path := filepath.Join(tmpDir, "file%d.md")
+		os.WriteFile(path, []byte("# File %d"), 0644)
+	}
+
+	embedder := NewMockEmbedder(128)
+	rag := NewRAGManager(embedder, DefaultRAGConfig())
+
+	si := NewStreamIndexer(rag, StreamConfig{
+		WatchDirs:  []string{tmpDir},
+		Extensions: []string{".md"},
+	})
+
+	si.Snapshot()
+
+	// Add files to queue manually
+	si.Queue().Add(filepath.Join(tmpDir, "file0.md"), ChangeAdded, 5)
+	si.Queue().Add(filepath.Join(tmpDir, "file1.md"), ChangeAdded, 5)
+	si.Queue().Add(filepath.Join(tmpDir, "file2.md"), ChangeAdded, 5)
+
+	// Process batch
+	jobs, docs, errs := si.ProcessBatch(context.Background(), 2)
+
+	if len(jobs) != 2 {
+		t.Errorf("expected 2 jobs, got %d", len(jobs))
+	}
+	if len(docs) != 2 {
+		t.Errorf("expected 2 docs, got %d", len(docs))
+	}
+
+	// Check for errors (some may fail if files don't exist)
+	for i, err := range errs {
+		if err != nil {
+			t.Logf("job %d error: %v", i, err)
+		}
+	}
+
+	// Queue should have 1 remaining
+	if si.Queue().Len() != 1 {
+		t.Errorf("expected 1 job remaining, got %d", si.Queue().Len())
+	}
+}
+
+func TestStreamIndexerStats(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	embedder := NewMockEmbedder(128)
+	rag := NewRAGManager(embedder, DefaultRAGConfig())
+
+	si := NewStreamIndexer(rag, StreamConfig{
+		WatchDirs:  []string{tmpDir},
+		Extensions: []string{".md"},
+		Workers:    2,
+	})
+
+	stats := si.Stats()
+
+	if stats.Running {
+		t.Error("expected not running initially")
+	}
+	if len(stats.WatchDirs) != 1 {
+		t.Errorf("expected 1 watch dir, got %d", len(stats.WatchDirs))
+	}
+}
+
+func TestStreamIndexerAddRemoveWatchDir(t *testing.T) {
+	embedder := NewMockEmbedder(128)
+	rag := NewRAGManager(embedder, DefaultRAGConfig())
+
+	si := NewStreamIndexer(rag, DefaultStreamConfig())
+
+	// Add watch dir
+	si.AddWatchDir("/path/to/dir1")
+	si.AddWatchDir("/path/to/dir2")
+
+	stats := si.Stats()
+	if len(stats.WatchDirs) != 2 {
+		t.Errorf("expected 2 watch dirs, got %d", len(stats.WatchDirs))
+	}
+
+	// Remove watch dir
+	si.RemoveWatchDir("/path/to/dir1")
+
+	stats = si.Stats()
+	if len(stats.WatchDirs) != 1 {
+		t.Errorf("expected 1 watch dir after remove, got %d", len(stats.WatchDirs))
+	}
+}
+
+func TestStreamIndexerStartStop(t *testing.T) {
+	embedder := NewMockEmbedder(128)
+	rag := NewRAGManager(embedder, DefaultRAGConfig())
+
+	si := NewStreamIndexer(rag, StreamConfig{
+		Workers: 1,
+	})
+
+	if si.IsRunning() {
+		t.Error("expected not running initially")
+	}
+
+	// Start
+	si.Start()
+	if !si.IsRunning() {
+		t.Error("expected running after Start()")
+	}
+
+	// Double start should be no-op
+	si.Start()
+	if !si.IsRunning() {
+		t.Error("expected still running")
+	}
+
+	// Stop
+	si.Stop()
+	// Give time for goroutines to stop
+	time.Sleep(100 * time.Millisecond)
+
+	if si.IsRunning() {
+		t.Error("expected not running after Stop()")
+	}
+
+	// Double stop should be no-op
+	si.Stop()
+}
+
+func TestStreamIndexerOnChangeCallback(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	file1 := filepath.Join(tmpDir, "callback.md")
+	os.WriteFile(file1, []byte("# Callback Test"), 0644)
+
+	embedder := NewMockEmbedder(128)
+	rag := NewRAGManager(embedder, DefaultRAGConfig())
+
+	si := NewStreamIndexer(rag, StreamConfig{
+		WatchDirs:  []string{tmpDir},
+		Extensions: []string{".md"},
+	})
+
+	var callbackCalled bool
+	var receivedChange FileChange
+
+	si.OnChange = func(change FileChange) {
+		callbackCalled = true
+		receivedChange = change
+	}
+
+	si.Snapshot()
+
+	// Modify file
+	time.Sleep(10 * time.Millisecond)
+	os.WriteFile(file1, []byte("# Callback Test Modified"), 0644)
+
+	// Scan should trigger callback
+	si.Scan()
+
+	if !callbackCalled {
+		t.Error("expected OnChange callback to be called")
+	}
+	if receivedChange.Type != ChangeModified {
+		t.Errorf("expected ChangeModified, got %v", receivedChange.Type)
+	}
+}
+
+func TestStreamIndexerOnIndexCallback(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	file1 := filepath.Join(tmpDir, "index_callback.md")
+	os.WriteFile(file1, []byte("# Index Callback Test"), 0644)
+
+	embedder := NewMockEmbedder(128)
+	rag := NewRAGManager(embedder, DefaultRAGConfig())
+
+	si := NewStreamIndexer(rag, StreamConfig{
+		WatchDirs:  []string{tmpDir},
+		Extensions: []string{".md"},
+	})
+
+	si.Snapshot()
+
+	var callbackCalled bool
+	var receivedJob *IndexJob
+
+	si.OnIndex = func(job *IndexJob, doc *Document, err error) {
+		callbackCalled = true
+		receivedJob = job
+	}
+
+	// Add job and process
+	si.Queue().Add(file1, ChangeAdded, 5)
+	si.ProcessOne(context.Background())
+
+	if !callbackCalled {
+		t.Error("expected OnIndex callback to be called")
+	}
+	if receivedJob == nil {
+		t.Fatal("expected job in callback")
+	}
+	if receivedJob.Path != file1 {
+		t.Errorf("expected path %s, got %s", file1, receivedJob.Path)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -202,6 +202,16 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/api/v1/rag/stats", s.handleRAGStats)
 	mux.HandleFunc("/api/v1/rag/store", s.handleRAGStore) // v0.21.0: SQLite 持久化
 
+	// v0.23.0: 流式 RAG
+	mux.HandleFunc("/api/v1/rag/stream/watch", s.handleRAGStreamWatch)
+	mux.HandleFunc("/api/v1/rag/stream/scan", s.handleRAGStreamScan)
+	mux.HandleFunc("/api/v1/rag/stream/start", s.handleRAGStreamStart)
+	mux.HandleFunc("/api/v1/rag/stream/stop", s.handleRAGStreamStop)
+	mux.HandleFunc("/api/v1/rag/stream/status", s.handleRAGStreamStatus)
+	mux.HandleFunc("/api/v1/rag/stream/index", s.handleRAGStreamIndex)
+	mux.HandleFunc("/api/v1/rag/stream/queue", s.handleRAGStreamQueue)
+	mux.HandleFunc("/api/v1/rag/stream/process", s.handleRAGStreamProcess)
+
 	// v0.15.0: Plugin API
 	mux.HandleFunc("/api/v1/plugins", s.handlePlugins)
 	mux.HandleFunc("/api/v1/plugins/search", s.handlePluginSearch)

--- a/internal/server/stream_handlers.go
+++ b/internal/server/stream_handlers.go
@@ -1,0 +1,316 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// handleRAGStreamWatch handles watch directory operations
+// POST: add watch directory
+// DELETE: remove watch directory
+func (s *Server) handleRAGStreamWatch(w http.ResponseWriter, r *http.Request) {
+	streamIndexer := s.agent.StreamIndexer()
+	if streamIndexer == nil {
+		s.sendError(w, "stream indexer not initialized", http.StatusServiceUnavailable, "")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPost:
+		var req struct {
+			Dir string `json:"dir"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			s.sendError(w, "invalid request body", http.StatusBadRequest, err.Error())
+			return
+		}
+		if req.Dir == "" {
+			s.sendError(w, "dir is required", http.StatusBadRequest, "")
+			return
+		}
+
+		streamIndexer.AddWatchDir(req.Dir)
+		s.sendJSON(w, http.StatusOK, map[string]interface{}{
+			"action": "add_watch",
+			"dir":    req.Dir,
+		})
+
+	case http.MethodDelete:
+		var req struct {
+			Dir string `json:"dir"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			s.sendError(w, "invalid request body", http.StatusBadRequest, err.Error())
+			return
+		}
+		if req.Dir == "" {
+			s.sendError(w, "dir is required", http.StatusBadRequest, "")
+			return
+		}
+
+		streamIndexer.RemoveWatchDir(req.Dir)
+		s.sendJSON(w, http.StatusOK, map[string]interface{}{
+			"action": "remove_watch",
+			"dir":    req.Dir,
+		})
+
+	default:
+		s.sendError(w, "method not allowed", http.StatusMethodNotAllowed, "")
+	}
+}
+
+// handleRAGStreamScan triggers a change scan
+func (s *Server) handleRAGStreamScan(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		s.sendError(w, "method not allowed", http.StatusMethodNotAllowed, "")
+		return
+	}
+
+	streamIndexer := s.agent.StreamIndexer()
+	if streamIndexer == nil {
+		s.sendError(w, "stream indexer not initialized", http.StatusServiceUnavailable, "")
+		return
+	}
+
+	changes := streamIndexer.Scan()
+
+	// Convert changes to response format
+	changeResults := make([]map[string]interface{}, len(changes))
+	for i, c := range changes {
+		changeResults[i] = map[string]interface{}{
+			"path":      c.Path,
+			"type":      c.Type.String(),
+			"timestamp": c.Timestamp,
+		}
+	}
+
+	s.sendJSON(w, http.StatusOK, map[string]interface{}{
+		"changes":     len(changes),
+		"queue_len":   streamIndexer.Queue().Len(),
+		"details":     changeResults,
+	})
+}
+
+// handleRAGStreamStart starts background workers
+func (s *Server) handleRAGStreamStart(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		s.sendError(w, "method not allowed", http.StatusMethodNotAllowed, "")
+		return
+	}
+
+	streamIndexer := s.agent.StreamIndexer()
+	if streamIndexer == nil {
+		s.sendError(w, "stream indexer not initialized", http.StatusServiceUnavailable, "")
+		return
+	}
+
+	if streamIndexer.IsRunning() {
+		s.sendJSON(w, http.StatusOK, map[string]interface{}{
+			"status":  "already_running",
+			"message": "stream indexer is already running",
+		})
+		return
+	}
+
+	streamIndexer.Start()
+	s.sendJSON(w, http.StatusOK, map[string]interface{}{
+		"status":  "started",
+		"message": "stream indexer started",
+	})
+}
+
+// handleRAGStreamStop stops background workers
+func (s *Server) handleRAGStreamStop(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		s.sendError(w, "method not allowed", http.StatusMethodNotAllowed, "")
+		return
+	}
+
+	streamIndexer := s.agent.StreamIndexer()
+	if streamIndexer == nil {
+		s.sendError(w, "stream indexer not initialized", http.StatusServiceUnavailable, "")
+		return
+	}
+
+	if !streamIndexer.IsRunning() {
+		s.sendJSON(w, http.StatusOK, map[string]interface{}{
+			"status":  "already_stopped",
+			"message": "stream indexer is not running",
+		})
+		return
+	}
+
+	streamIndexer.Stop()
+	s.sendJSON(w, http.StatusOK, map[string]interface{}{
+		"status":  "stopped",
+		"message": "stream indexer stopped",
+	})
+}
+
+// handleRAGStreamStatus returns stream indexer status
+func (s *Server) handleRAGStreamStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		s.sendError(w, "method not allowed", http.StatusMethodNotAllowed, "")
+		return
+	}
+
+	streamIndexer := s.agent.StreamIndexer()
+	if streamIndexer == nil {
+		s.sendJSON(w, http.StatusOK, map[string]interface{}{
+			"initialized": false,
+			"message":     "stream indexer not configured",
+		})
+		return
+	}
+
+	stats := streamIndexer.Stats()
+	s.sendJSON(w, http.StatusOK, map[string]interface{}{
+		"initialized":   true,
+		"running":       stats.Running,
+		"queue_len":     stats.QueueLen,
+		"watch_dirs":    stats.WatchDirs,
+		"tracked_files": stats.TrackedFiles,
+	})
+}
+
+// handleRAGStreamIndex handles immediate path indexing
+// POST: index a path immediately
+// DELETE: remove a path from index
+func (s *Server) handleRAGStreamIndex(w http.ResponseWriter, r *http.Request) {
+	streamIndexer := s.agent.StreamIndexer()
+	if streamIndexer == nil {
+		s.sendError(w, "stream indexer not initialized", http.StatusServiceUnavailable, "")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPost:
+		var req struct {
+			Path string `json:"path"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			s.sendError(w, "invalid request body", http.StatusBadRequest, err.Error())
+			return
+		}
+		if req.Path == "" {
+			s.sendError(w, "path is required", http.StatusBadRequest, "")
+			return
+		}
+
+		doc, err := streamIndexer.IndexPath(req.Path)
+		if err != nil {
+			s.sendError(w, "index path failed", http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		s.sendJSON(w, http.StatusOK, map[string]interface{}{
+			"action":    "index_path",
+			"doc_id":    doc.ID,
+			"title":     doc.Title,
+			"chunks":    len(doc.Chunks),
+			"indexed_at": doc.IndexedAt,
+		})
+
+	case http.MethodDelete:
+		var req struct {
+			Path string `json:"path"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			s.sendError(w, "invalid request body", http.StatusBadRequest, err.Error())
+			return
+		}
+		if req.Path == "" {
+			s.sendError(w, "path is required", http.StatusBadRequest, "")
+			return
+		}
+
+		removed := streamIndexer.RemovePath(req.Path)
+		s.sendJSON(w, http.StatusOK, map[string]interface{}{
+			"action":  "remove_path",
+			"path":    req.Path,
+			"removed": removed,
+		})
+
+	default:
+		s.sendError(w, "method not allowed", http.StatusMethodNotAllowed, "")
+	}
+}
+
+// handleRAGStreamQueue returns pending jobs in the queue
+func (s *Server) handleRAGStreamQueue(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		s.sendError(w, "method not allowed", http.StatusMethodNotAllowed, "")
+		return
+	}
+
+	streamIndexer := s.agent.StreamIndexer()
+	if streamIndexer == nil {
+		s.sendError(w, "stream indexer not initialized", http.StatusServiceUnavailable, "")
+		return
+	}
+
+	jobs := streamIndexer.Queue().List()
+	jobResults := make([]map[string]interface{}, len(jobs))
+	for i, job := range jobs {
+		jobResults[i] = map[string]interface{}{
+			"id":        job.ID,
+			"path":      job.Path,
+			"type":      job.JobType.String(),
+			"priority":  job.Priority,
+			"created_at": job.CreatedAt,
+		}
+	}
+
+	s.sendJSON(w, http.StatusOK, map[string]interface{}{
+		"total": len(jobs),
+		"jobs":  jobResults,
+	})
+}
+
+// handleRAGStreamProcess processes pending jobs
+func (s *Server) handleRAGStreamProcess(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		s.sendError(w, "method not allowed", http.StatusMethodNotAllowed, "")
+		return
+	}
+
+	var req struct {
+		Batch int `json:"batch,omitempty"` // number of jobs to process, default 1
+	}
+	json.NewDecoder(r.Body).Decode(&req)
+	if req.Batch <= 0 {
+		req.Batch = 1
+	}
+
+	streamIndexer := s.agent.StreamIndexer()
+	if streamIndexer == nil {
+		s.sendError(w, "stream indexer not initialized", http.StatusServiceUnavailable, "")
+		return
+	}
+
+	jobs, docs, errs := streamIndexer.ProcessBatch(r.Context(), req.Batch)
+
+	results := make([]map[string]interface{}, len(jobs))
+	for i := range jobs {
+		result := map[string]interface{}{
+			"job_id":   jobs[i].ID,
+			"path":     jobs[i].Path,
+			"type":     jobs[i].JobType.String(),
+			"error":    nil,
+		}
+		if errs[i] != nil {
+			result["error"] = errs[i].Error()
+		}
+		if docs[i] != nil {
+			result["doc_id"] = docs[i].ID
+			result["title"] = docs[i].Title
+			result["chunks"] = len(docs[i].Chunks)
+		}
+		results[i] = result
+	}
+
+	s.sendJSON(w, http.StatusOK, map[string]interface{}{
+		"processed": len(jobs),
+		"results":   results,
+	})
+}

--- a/internal/server/stream_handlers_test.go
+++ b/internal/server/stream_handlers_test.go
@@ -1,0 +1,279 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/yurika0211/luckyharness/internal/agent"
+	"github.com/yurika0211/luckyharness/internal/config"
+)
+
+func TestHandleRAGStreamStatus(t *testing.T) {
+	mgr, err := config.NewManager()
+	if err != nil {
+		t.Fatalf("create config manager: %v", err)
+	}
+	mgr.Load()
+
+	a, err := agent.New(mgr)
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	s := New(a, DefaultServerConfig())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/rag/stream/status", nil)
+	w := httptest.NewRecorder()
+
+	s.handleRAGStreamStatus(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if initialized, ok := resp["initialized"].(bool); !ok || !initialized {
+		t.Error("expected initialized=true")
+	}
+}
+
+func TestHandleRAGStreamWatch(t *testing.T) {
+	mgr, err := config.NewManager()
+	if err != nil {
+		t.Fatalf("create config manager: %v", err)
+	}
+	mgr.Load()
+
+	a, err := agent.New(mgr)
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	s := New(a, DefaultServerConfig())
+
+	// Test POST - add watch
+	body := bytes.NewBufferString(`{"dir":"/tmp"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/rag/stream/watch", body)
+	w := httptest.NewRecorder()
+
+	s.handleRAGStreamWatch(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if resp["action"] != "add_watch" {
+		t.Errorf("expected action=add_watch, got %v", resp["action"])
+	}
+
+	// Test DELETE - remove watch
+	body = bytes.NewBufferString(`{"dir":"/tmp"}`)
+	req = httptest.NewRequest(http.MethodDelete, "/api/v1/rag/stream/watch", body)
+	w = httptest.NewRecorder()
+
+	s.handleRAGStreamWatch(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+
+	// Test invalid method
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/rag/stream/watch", nil)
+	w = httptest.NewRecorder()
+
+	s.handleRAGStreamWatch(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected status 405, got %d", w.Code)
+	}
+}
+
+func TestHandleRAGStreamScan(t *testing.T) {
+	mgr, err := config.NewManager()
+	if err != nil {
+		t.Fatalf("create config manager: %v", err)
+	}
+	mgr.Load()
+
+	a, err := agent.New(mgr)
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	s := New(a, DefaultServerConfig())
+
+	// Test POST
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/rag/stream/scan", nil)
+	w := httptest.NewRecorder()
+
+	s.handleRAGStreamScan(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if _, ok := resp["changes"]; !ok {
+		t.Error("expected changes field in response")
+	}
+
+	// Test invalid method
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/rag/stream/scan", nil)
+	w = httptest.NewRecorder()
+
+	s.handleRAGStreamScan(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected status 405, got %d", w.Code)
+	}
+}
+
+func TestHandleRAGStreamStartStop(t *testing.T) {
+	mgr, err := config.NewManager()
+	if err != nil {
+		t.Fatalf("create config manager: %v", err)
+	}
+	mgr.Load()
+
+	a, err := agent.New(mgr)
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	s := New(a, DefaultServerConfig())
+
+	// Test start
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/rag/stream/start", nil)
+	w := httptest.NewRecorder()
+
+	s.handleRAGStreamStart(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if resp["status"] != "started" && resp["status"] != "already_running" {
+		t.Errorf("expected status=started or already_running, got %v", resp["status"])
+	}
+
+	// Test stop
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/rag/stream/stop", nil)
+	w = httptest.NewRecorder()
+
+	s.handleRAGStreamStop(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+
+	// Test invalid method
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/rag/stream/start", nil)
+	w = httptest.NewRecorder()
+
+	s.handleRAGStreamStart(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected status 405, got %d", w.Code)
+	}
+}
+
+func TestHandleRAGStreamQueue(t *testing.T) {
+	mgr, err := config.NewManager()
+	if err != nil {
+		t.Fatalf("create config manager: %v", err)
+	}
+	mgr.Load()
+
+	a, err := agent.New(mgr)
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	s := New(a, DefaultServerConfig())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/rag/stream/queue", nil)
+	w := httptest.NewRecorder()
+
+	s.handleRAGStreamQueue(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if _, ok := resp["total"]; !ok {
+		t.Error("expected total field in response")
+	}
+	if _, ok := resp["jobs"]; !ok {
+		t.Error("expected jobs field in response")
+	}
+}
+
+func TestHandleRAGStreamProcess(t *testing.T) {
+	mgr, err := config.NewManager()
+	if err != nil {
+		t.Fatalf("create config manager: %v", err)
+	}
+	mgr.Load()
+
+	a, err := agent.New(mgr)
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	s := New(a, DefaultServerConfig())
+
+	// Test POST with empty queue
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/rag/stream/process", nil)
+	w := httptest.NewRecorder()
+
+	s.handleRAGStreamProcess(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if processed, ok := resp["processed"].(float64); !ok || int(processed) != 0 {
+		t.Errorf("expected processed=0, got %v", resp["processed"])
+	}
+
+	// Test invalid method
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/rag/stream/process", nil)
+	w = httptest.NewRecorder()
+
+	s.handleRAGStreamProcess(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected status 405, got %d", w.Code)
+	}
+}


### PR DESCRIPTION
## 新增功能

### StreamIndexer 接口 (internal/rag/stream.go)
- 增量添加/更新/删除文档
- IndexQueue — 索引任务队列，支持批处理和去重
- ChangeDetector — 文件哈希对比，识别新增/修改/删除
- FileWatcher 集成 — 监控目录变更，自动触发索引
- 后台 worker 池处理索引任务

### API 端点 (internal/server/stream_handlers.go)
- POST /api/v1/rag/stream/watch — 添加监控目录
- DELETE /api/v1/rag/stream/watch — 移除监控目录
- POST /api/v1/rag/stream/scan — 扫描变更
- POST /api/v1/rag/stream/start — 启动后台索引
- POST /api/v1/rag/stream/stop — 停止后台索引
- GET /api/v1/rag/stream/status — 流式索引状态
- GET /api/v1/rag/stream/queue — 查看索引队列
- POST /api/v1/rag/stream/process — 处理索引队列

### REPL 命令 (cmd/lh/main.go)
- lh rag watch/unwatch/scan/start/stop/status/queue/process

## 测试覆盖

- internal/rag/stream_test.go — 14 tests
- internal/server/stream_handlers_test.go — 8 tests
- Total: 22 new tests, all passing with -race flag