### PR TITLE
`fix: gateway runtime control + telegram command runtime + agent loop guard`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ cover.out
 tmp
 .env
 .codex
-.lh-home
+.lh-home*

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ tasks/bangumi_published.json
 lh-new
 coverage.out
 cover.out
+tmp
+.env
+.codex
+.lh-home

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v0.38.2 — Provider Resilience & Config Wiring (2026-04-24)
+
+### 🐛 Fixes
+
+- Wired runtime provider safety configs from app config to provider layer:
+  - limits / retry / circuit_breaker / rate_limit / context are now propagated when creating provider config.
+- Hardened OpenAI-compatible HTTP request path:
+  - Added dedicated HTTP client/transport for OpenAI calls.
+  - Disabled HTTP/2 attempt on this path to reduce flaky proxy behavior.
+  - Added transport-level retry with exponential backoff for retryable network/TLS failures.
+  - Retries force fresh connection on subsequent attempts (`req.Close = true` + close idle conns).
+- Added retry classification for common transient failures:
+  - `tls: bad record mac`, timeout-like errors, connection reset/lost/unexpected EOF variants.
+
+### 🧪 Tests
+
+- Added `openai_stream_retry_test.go` to verify:
+  - retryable TLS error detection
+  - request retries are attempted and second attempt forces new connection
+
 ## v0.38.1 — Stability & Gateway Reliability (2026-04-24)
 
 ### 🐛 Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v0.38.1 — Stability & Gateway Reliability (2026-04-24)
+
+### 🐛 Fixes
+
+- Fixed Telegram `msg-gateway` startup concurrency bug in CLI path
+  - Removed invalid `WaitGroup` usage (`Done` without matching `Add`)
+  - API server startup now returns explicit startup errors
+- Unified Telegram chat-session persistence path between CLI and HTTP API
+  - Both now use `Config().HomeDir()/data/telegram`
+- Fixed legacy tool-history compatibility for OpenAI-compatible gateways
+  - Prevent `Invalid input[*].call_id: empty string` by downgrading invalid legacy `tool` messages before request encoding
+- Persisted structured tool-call metadata in session history
+  - Preserve `assistant.tool_calls` and `tool.tool_call_id` instead of flattening to plain text
+- Enforced max-iteration boundary in streaming conversation path
+  - Native/simulated streaming recursion now decrements remaining iterations and exits with `max iterations reached`
+
+### 🧪 Tests
+
+- Added regression test for stream path max-iteration enforcement
+- Added provider/session tests for tool-call metadata and legacy compatibility
+
 ## v0.38.0 — Agent Autonomy Kit (2026-04-21)
 
 ### 🧠 New: `internal/autonomy` — Native Agent Autonomy Kit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.38.3 — Gateway Control & Telegram Command Runtime (2026-04-24)
+
+### 🐛 Fixes
+
+- `lh msg-gateway status/stop` now controls the running gateway process via HTTP API instead of local in-memory state.
+  - Added `--api-addr` for both commands (defaults to `msg_gateway.api_addr`, then `127.0.0.1:9090`).
+  - Improved API error propagation with structured fallback parsing.
+- Implemented Telegram `/stop` real task cancellation:
+  - Added per-chat cancellable task tracking.
+  - `/stop` now cancels active request and returns immediate feedback.
+- Implemented Telegram `/restart` runtime reconnect:
+  - Added adapter stop/start reconnect flow with anti-reentry guard.
+  - Bot reports reconnect result in-chat after restart attempt.
+- Decoupled Telegram message handling from update loop by dispatching chat processing asynchronously.
+  - Prevents long-running chat from blocking command handling.
+
 ## v0.38.2 — Provider Resilience & Config Wiring (2026-04-24)
 
 ### 🐛 Fixes

--- a/README.md
+++ b/README.md
@@ -888,6 +888,51 @@ lh models
 /models
 ```
 
+### 本地接入 Telegram（含代理）
+
+如果你是源码运行（`go run ./cmd/lh ...`），推荐按下面流程配置：
+
+```bash
+# 可选：把数据目录放到项目内，避免 ~/.luckyharness 不可写
+export HOME="$PWD/.lh-home"
+mkdir -p "$HOME"
+
+# 初始化与 LLM 配置
+go run ./cmd/lh init
+go run ./cmd/lh config set provider openai
+go run ./cmd/lh config set api_key sk-xxx
+go run ./cmd/lh config set model gpt-4o
+go run ./cmd/lh config set api_base https://api.openai.com/v1
+go run ./cmd/lh config get api_base
+```
+
+`api_base` 存在配置文件中：
+- 默认路径：`~/.luckyharness/config.json`
+- 若设置 `HOME="$PWD/.lh-home"`：`./.lh-home/.luckyharness/config.json`
+
+先验证 Telegram API 连通性（示例使用本地代理 `127.0.0.1:7897`）：
+
+```bash
+export TG_TOKEN="123456:ABC-DEF"
+curl -x http://127.0.0.1:7897 -m 20 "https://api.telegram.org/bot${TG_TOKEN}/getMe"
+```
+
+返回 `{"ok":true,...}` 后再启动网关：
+
+```bash
+export HTTPS_PROXY=http://127.0.0.1:7897
+export HTTP_PROXY=http://127.0.0.1:7897
+export NO_PROXY=127.0.0.1,localhost
+go run ./cmd/lh msg-gateway start --platform telegram --token "$TG_TOKEN" --api-addr=127.0.0.1:19090
+```
+
+常见问题：
+
+- `flag needs an argument: --api-addr`：命令被换行拆断，建议使用 `--api-addr=127.0.0.1:19090`。
+- `Conflict: terminated by other getUpdates request`：同一 Bot 有多个实例同时在轮询，关闭其他实例，仅保留一个进程。
+- `Connection timed out`（`api.telegram.org`）：当前网络不可达，需配置可用代理后重试。
+- Token 泄露后请立刻到 `@BotFather` 重新生成新 Token。
+
 ## v0.3.0 新特性
 
 ### Provider 自动降级链

--- a/cmd/lh/chat_repl.go
+++ b/cmd/lh/chat_repl.go
@@ -63,6 +63,13 @@ func startREPL(mgr *config.Manager) error {
 	fmt.Println()
 
 	loopCfg := agent.DefaultLoopConfig()
+	if cfg.Agent.MaxIterations > 0 {
+		loopCfg.MaxIterations = cfg.Agent.MaxIterations
+	}
+	if cfg.Agent.TimeoutSeconds > 0 {
+		loopCfg.Timeout = time.Duration(cfg.Agent.TimeoutSeconds) * time.Second
+	}
+	loopCfg.AutoApprove = cfg.Agent.AutoApprove
 	scanner := bufio.NewScanner(os.Stdin)
 	ctx := context.Background()
 
@@ -179,12 +186,12 @@ func handleCommand(input string, a *agent.Agent, loopCfg *agent.LoopConfig, cron
 		fmt.Println("  /serve [addr]      启动 API Server")
 		fmt.Println("  /context           上下文窗口状态")
 		fmt.Println("  /context fit       手动触发上下文裁剪")
-fmt.Println("  /rag index <path>  索引文件/目录到知识库")
-	fmt.Println("  /rag search <q>    搜索知识库")
-	fmt.Println("  /rag stats         知识库统计")
-	fmt.Println("  /rag store         存储后端信息")
-	fmt.Println("  /rag list          列出文档")
-	fmt.Println("  /rag remove <id>   删除文档")
+		fmt.Println("  /rag index <path>  索引文件/目录到知识库")
+		fmt.Println("  /rag search <q>    搜索知识库")
+		fmt.Println("  /rag stats         知识库统计")
+		fmt.Println("  /rag store         存储后端信息")
+		fmt.Println("  /rag list          列出文档")
+		fmt.Println("  /rag remove <id>   删除文档")
 		fmt.Println("  /fc tools          列出 Function Calling 工具")
 		fmt.Println("  /fc history        查看调用历史")
 		fmt.Println("  /fc clear          清除调用历史")
@@ -857,10 +864,10 @@ func handleContextCommand(arg string, a *agent.Agent) bool {
 			return true
 		}
 		strategyMap := map[string]contextx.TrimStrategy{
-			"oldest_first":      contextx.TrimOldest,
+			"oldest_first":       contextx.TrimOldest,
 			"low_priority_first": contextx.TrimLowPriority,
-			"sliding_window":    contextx.TrimSlidingWindow,
-			"summarize":         contextx.TrimSummarize,
+			"sliding_window":     contextx.TrimSlidingWindow,
+			"summarize":          contextx.TrimSummarize,
 		}
 		if strategy, ok := strategyMap[parts[1]]; ok {
 			fmt.Printf("✅ 裁剪策略: %s (重启后生效)\n", strategy.String())

--- a/cmd/lh/main.go
+++ b/cmd/lh/main.go
@@ -133,7 +133,7 @@ func main() {
 		Use:   "version",
 		Short: "显示版本",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("🍀 LuckyHarness v0.38.1")
+			fmt.Println("🍀 LuckyHarness v0.38.2")
 		},
 	}
 

--- a/cmd/lh/main.go
+++ b/cmd/lh/main.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"sync"
 	"os/signal"
 	"path/filepath"
 	"strings"
@@ -26,6 +25,8 @@ import (
 	dbg "github.com/yurika0211/luckyharness/internal/debug"
 	"github.com/yurika0211/luckyharness/internal/eval"
 	"github.com/yurika0211/luckyharness/internal/gateway"
+	"github.com/yurika0211/luckyharness/internal/gateway/onebot"
+	"github.com/yurika0211/luckyharness/internal/gateway/telegram"
 	"github.com/yurika0211/luckyharness/internal/health"
 	"github.com/yurika0211/luckyharness/internal/logger"
 	"github.com/yurika0211/luckyharness/internal/profile"
@@ -34,15 +35,13 @@ import (
 	"github.com/yurika0211/luckyharness/internal/server"
 	"github.com/yurika0211/luckyharness/internal/soul"
 	"github.com/yurika0211/luckyharness/internal/tool"
-	"github.com/yurika0211/luckyharness/internal/gateway/onebot"
-	"github.com/yurika0211/luckyharness/internal/gateway/telegram"
 )
 
 var (
 	soulFile  string
 	provider_ string
-	model_   string
-	yolo     bool
+	model_    string
+	yolo      bool
 	// eval command flags
 	evalFormat    string
 	evalThreshold float64
@@ -134,7 +133,7 @@ func main() {
 		Use:   "version",
 		Short: "显示版本",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("🍀 LuckyHarness v0.38.0")
+			fmt.Println("🍀 LuckyHarness v0.38.1")
 		},
 	}
 
@@ -1325,9 +1324,6 @@ func runMsgGatewayStart(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// WaitGroup to ensure all goroutines complete before exiting
-	var wg sync.WaitGroup
-
 	// v0.36.0: 同时启动 HTTP API Server
 	apiAddr, _ := cmd.Flags().GetString("api-addr")
 	if apiAddr == "" {
@@ -1338,12 +1334,9 @@ func runMsgGatewayStart(cmd *cobra.Command, args []string) error {
 		EnableCORS: false,
 		RateLimit:  60,
 	})
-	go func() {
-		if err := srv.Start(); err != nil {
-		defer wg.Done()
-			fmt.Printf("[server] HTTP API error: %v\n", err)
-		}
-	}()
+	if err := srv.Start(); err != nil {
+		return fmt.Errorf("start http api server: %w", err)
+	}
 	fmt.Printf("📡 HTTP API server starting on %s\n", apiAddr)
 
 	startAll, _ := cmd.Flags().GetBool("all")
@@ -1359,7 +1352,6 @@ func runMsgGatewayStart(cmd *cobra.Command, args []string) error {
 		fmt.Println("\n🛑 正在停止所有消息网关...")
 		_ = gm.StopAll()
 		_ = srv.Stop()
-		wg.Wait()
 		return nil
 	}
 
@@ -1374,8 +1366,7 @@ func runMsgGatewayStart(cmd *cobra.Command, args []string) error {
 		tgAdapter := telegram.NewAdapter(telegram.Config{Token: token})
 		handler := telegram.NewHandler(tgAdapter, a)
 		// 持久化 chatID→sessionID 映射，重启后恢复会话
-		home, _ := os.UserHomeDir()
-		handler.SetDataDir(filepath.Join(home, ".luckyharness", "data", "telegram"))
+		handler.SetDataDir(filepath.Join(a.Config().HomeDir(), "data", "telegram"))
 		tgAdapter.SetHandler(func(ctx context.Context, msg *gateway.Message) error {
 			return handler.HandleMessage(ctx, msg)
 		})
@@ -1401,13 +1392,13 @@ func runMsgGatewayStart(cmd *cobra.Command, args []string) error {
 		}
 
 		obAdapter := onebot.NewAdapter(onebot.Config{
-			APIBase:      apiBase,
-			WSURL:        wsURL,
-			AccessToken:  obToken,
-			BotQQID:      botID,
-			ShowTyping:   showTyping,
-			AutoLike:     autoLike,
-			LikeTimes:    likeTimes,
+			APIBase:       apiBase,
+			WSURL:         wsURL,
+			AccessToken:   obToken,
+			BotQQID:       botID,
+			ShowTyping:    showTyping,
+			AutoLike:      autoLike,
+			LikeTimes:     likeTimes,
 			MaxMessageLen: 4000,
 		})
 		obHandler := onebot.NewHandler(obAdapter, a)
@@ -1563,7 +1554,7 @@ func runSubInfo(cmd *cobra.Command, args []string) error {
 
 	// 显示等级配置
 	config := a.Gateway().Subscriptions().GetTierConfig(sub.Tier)
-	fmt.Printf("  每日限额: ", )
+	fmt.Printf("  每日限额: ")
 	if config.MaxCallsPerDay == 0 {
 		fmt.Println("无限")
 	} else {

--- a/cmd/lh/main.go
+++ b/cmd/lh/main.go
@@ -764,7 +764,17 @@ func runChat(cmd *cobra.Command, args []string) error {
 	}
 
 	loopCfg := agent.DefaultLoopConfig()
-	loopCfg.AutoApprove = yolo
+	cfg := mgr.Get()
+	if cfg.Agent.MaxIterations > 0 {
+		loopCfg.MaxIterations = cfg.Agent.MaxIterations
+	}
+	if cfg.Agent.TimeoutSeconds > 0 {
+		loopCfg.Timeout = time.Duration(cfg.Agent.TimeoutSeconds) * time.Second
+	}
+	loopCfg.AutoApprove = cfg.Agent.AutoApprove
+	if cmd.Flags().Changed("yolo") {
+		loopCfg.AutoApprove = yolo
+	}
 
 	ctx := context.Background()
 	result, err := a.RunLoop(ctx, userInput, loopCfg)
@@ -1131,7 +1141,21 @@ func runBackupList(cmd *cobra.Command, args []string) error {
 // ===== v0.9.0: Dashboard 命令实现 =====
 
 func runDashboardStart(cmd *cobra.Command, args []string) error {
+	mgr, err := config.NewManager()
+	if err != nil {
+		return err
+	}
+	if err := mgr.Load(); err != nil {
+		return err
+	}
+
 	addr, _ := cmd.Flags().GetString("addr")
+	if !cmd.Flags().Changed("addr") {
+		if cfgAddr := mgr.Get().Dashboard.Addr; cfgAddr != "" {
+			addr = cfgAddr
+		}
+	}
+
 	cfg := dashboard.Config{Addr: addr}
 	d := dashboard.New(cfg)
 
@@ -1322,6 +1346,7 @@ func runMsgGatewayStart(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	cfg := a.Config().Get()
 
 	gm := a.MsgGateway()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1329,13 +1354,20 @@ func runMsgGatewayStart(cmd *cobra.Command, args []string) error {
 
 	// v0.36.0: 同时启动 HTTP API Server
 	apiAddr, _ := cmd.Flags().GetString("api-addr")
+	if !cmd.Flags().Changed("api-addr") && cfg.MsgGateway.APIAddr != "" {
+		apiAddr = cfg.MsgGateway.APIAddr
+	}
 	if apiAddr == "" {
 		apiAddr = "127.0.0.1:9090"
 	}
+	rateLimit := cfg.Server.RateLimit
+	if rateLimit <= 0 {
+		rateLimit = 60
+	}
 	srv := server.New(a, server.ServerConfig{
 		Addr:       apiAddr,
-		EnableCORS: false,
-		RateLimit:  60,
+		EnableCORS: cfg.Server.EnableCORS,
+		RateLimit:  rateLimit,
 	})
 	if err := srv.Start(); err != nil {
 		return fmt.Errorf("start http api server: %w", err)
@@ -1343,6 +1375,9 @@ func runMsgGatewayStart(cmd *cobra.Command, args []string) error {
 	fmt.Printf("📡 HTTP API server starting on %s\n", apiAddr)
 
 	startAll, _ := cmd.Flags().GetBool("all")
+	if !cmd.Flags().Changed("all") {
+		startAll = cfg.MsgGateway.StartAll
+	}
 	if startAll {
 		if err := gm.StartAll(ctx); err != nil {
 			return err
@@ -1359,12 +1394,22 @@ func runMsgGatewayStart(cmd *cobra.Command, args []string) error {
 	}
 
 	platform, _ := cmd.Flags().GetString("platform")
+	if !cmd.Flags().Changed("platform") && cfg.MsgGateway.Platform != "" {
+		platform = cfg.MsgGateway.Platform
+	}
 	token, _ := cmd.Flags().GetString("token")
+	if !cmd.Flags().Changed("token") {
+		if cfg.MsgGateway.Telegram.Token != "" {
+			token = cfg.MsgGateway.Telegram.Token
+		} else if cfg.MsgGateway.Token != "" {
+			token = cfg.MsgGateway.Token
+		}
+	}
 
 	switch platform {
 	case "telegram":
 		if token == "" {
-			return fmt.Errorf("telegram 需要 --token 参数")
+			return fmt.Errorf("telegram 需要 --token 参数（或在 config.json 里设置 msg_gateway.telegram.token）")
 		}
 		tgAdapter := telegram.NewAdapter(telegram.Config{Token: token})
 		handler := telegram.NewHandler(tgAdapter, a)
@@ -1383,15 +1428,36 @@ func runMsgGatewayStart(cmd *cobra.Command, args []string) error {
 
 	case "onebot":
 		apiBase, _ := cmd.Flags().GetString("onebot-api")
+		if !cmd.Flags().Changed("onebot-api") && cfg.MsgGateway.OneBot.APIBase != "" {
+			apiBase = cfg.MsgGateway.OneBot.APIBase
+		}
 		wsURL, _ := cmd.Flags().GetString("onebot-ws")
+		if !cmd.Flags().Changed("onebot-ws") && cfg.MsgGateway.OneBot.WSURL != "" {
+			wsURL = cfg.MsgGateway.OneBot.WSURL
+		}
 		obToken, _ := cmd.Flags().GetString("onebot-token")
+		if !cmd.Flags().Changed("onebot-token") && cfg.MsgGateway.OneBot.AccessToken != "" {
+			obToken = cfg.MsgGateway.OneBot.AccessToken
+		}
 		botID, _ := cmd.Flags().GetString("onebot-bot-id")
+		if !cmd.Flags().Changed("onebot-bot-id") && cfg.MsgGateway.OneBot.BotID != "" {
+			botID = cfg.MsgGateway.OneBot.BotID
+		}
 		showTyping, _ := cmd.Flags().GetBool("onebot-typing")
+		if !cmd.Flags().Changed("onebot-typing") {
+			showTyping = cfg.MsgGateway.OneBot.ShowTyping
+		}
 		autoLike, _ := cmd.Flags().GetBool("onebot-like")
+		if !cmd.Flags().Changed("onebot-like") {
+			autoLike = cfg.MsgGateway.OneBot.AutoLike
+		}
 		likeTimes, _ := cmd.Flags().GetInt("onebot-like-times")
+		if !cmd.Flags().Changed("onebot-like-times") && cfg.MsgGateway.OneBot.LikeTimes > 0 {
+			likeTimes = cfg.MsgGateway.OneBot.LikeTimes
+		}
 
 		if apiBase == "" {
-			return fmt.Errorf("onebot 需要 --onebot-api 参数")
+			return fmt.Errorf("onebot 需要 --onebot-api 参数（或在 config.json 里设置 msg_gateway.onebot.api_base）")
 		}
 
 		obAdapter := onebot.NewAdapter(onebot.Config{
@@ -1423,6 +1489,9 @@ func runMsgGatewayStart(cmd *cobra.Command, args []string) error {
 		}
 
 	default:
+		if platform == "" {
+			return fmt.Errorf("请通过 --platform 指定平台，或在 config.json 设置 msg_gateway.platform")
+		}
 		return fmt.Errorf("不支持的平台: %s (支持: telegram, onebot)", platform)
 	}
 
@@ -1458,6 +1527,7 @@ func runMsgGatewayStop(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("无法连接到消息网关 API (%s): %w\n提示: 先运行 `lh msg-gateway start ...`", baseURL, err)
 	}
 
+	// stop all running gateways
 	if len(args) == 0 {
 		if len(statuses) == 0 {
 			fmt.Println("📋 暂无已注册的消息网关")
@@ -1802,20 +1872,47 @@ func runServe(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("create agent: %w", err)
 	}
+	appCfg := mgr.Get()
 
 	addr, _ := cmd.Flags().GetString("addr")
+	if !cmd.Flags().Changed("addr") && appCfg.Server.Addr != "" {
+		addr = appCfg.Server.Addr
+	}
 	apiKeys, _ := cmd.Flags().GetStringSlice("api-keys")
+	if !cmd.Flags().Changed("api-keys") && len(appCfg.Server.APIKeys) > 0 {
+		apiKeys = append([]string(nil), appCfg.Server.APIKeys...)
+	}
 	noCORS, _ := cmd.Flags().GetBool("no-cors")
+	enableCORS := !noCORS
+	if !cmd.Flags().Changed("no-cors") {
+		enableCORS = appCfg.Server.EnableCORS
+	}
 	rateLimit, _ := cmd.Flags().GetInt("rate-limit")
+	if !cmd.Flags().Changed("rate-limit") && appCfg.Server.RateLimit > 0 {
+		rateLimit = appCfg.Server.RateLimit
+	}
 	metricsAddr, _ := cmd.Flags().GetString("metrics-addr")
+	if !cmd.Flags().Changed("metrics-addr") && appCfg.Server.MetricsAddr != "" {
+		metricsAddr = appCfg.Server.MetricsAddr
+	}
 	logLevel, _ := cmd.Flags().GetString("log-level")
+	if !cmd.Flags().Changed("log-level") && appCfg.Server.LogLevel != "" {
+		logLevel = appCfg.Server.LogLevel
+	}
 	logFormat, _ := cmd.Flags().GetString("log-format")
+	if !cmd.Flags().Changed("log-format") && appCfg.Server.LogFormat != "" {
+		logFormat = appCfg.Server.LogFormat
+	}
+	corsOrigins := []string{"*"}
+	if len(appCfg.Server.CORSOrigins) > 0 {
+		corsOrigins = append([]string(nil), appCfg.Server.CORSOrigins...)
+	}
 
 	cfg := server.ServerConfig{
 		Addr:        addr,
 		APIKeys:     apiKeys,
-		EnableCORS:  !noCORS,
-		CORSOrigins: []string{"*"},
+		EnableCORS:  enableCORS,
+		CORSOrigins: corsOrigins,
 		RateLimit:   rateLimit,
 		MetricsAddr: metricsAddr,
 		LogLevel:    logLevel,

--- a/cmd/lh/main.go
+++ b/cmd/lh/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -334,11 +335,13 @@ func main() {
 		Args:  cobra.MaximumNArgs(1),
 		RunE:  runMsgGatewayStop,
 	}
+	msgGatewayStopCmd.Flags().String("api-addr", "", "消息网关 API 地址（默认读取 msg_gateway.api_addr）")
 	msgGatewayStatusCmd := &cobra.Command{
 		Use:   "status",
 		Short: "查看消息网关状态",
 		RunE:  runMsgGatewayStatus,
 	}
+	msgGatewayStatusCmd.Flags().String("api-addr", "", "消息网关 API 地址（默认读取 msg_gateway.api_addr）")
 	msgGatewayCmd.AddCommand(msgGatewayStartCmd, msgGatewayStopCmd, msgGatewayStatusCmd)
 
 	// ===== v0.10.0: Subscription 命令 =====
@@ -1433,23 +1436,52 @@ func runMsgGatewayStart(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+type msgGatewayListResponse struct {
+	Gateways []gateway.GatewayStatus `json:"gateways"`
+	Count    int                     `json:"count"`
+}
+
+type msgGatewayErrorResponse struct {
+	Error   string `json:"error"`
+	Code    int    `json:"code"`
+	Details string `json:"details"`
+}
+
 func runMsgGatewayStop(cmd *cobra.Command, args []string) error {
-	a, err := getAgent()
+	baseURL, err := resolveMsgGatewayAPIBase(cmd)
 	if err != nil {
 		return err
 	}
 
-	gm := a.MsgGateway()
+	statuses, err := fetchMsgGatewayStatuses(baseURL)
+	if err != nil {
+		return fmt.Errorf("无法连接到消息网关 API (%s): %w\n提示: 先运行 `lh msg-gateway start ...`", baseURL, err)
+	}
 
 	if len(args) == 0 {
-		if err := gm.StopAll(); err != nil {
-			return err
+		if len(statuses) == 0 {
+			fmt.Println("📋 暂无已注册的消息网关")
+			return nil
 		}
-		fmt.Println("✅ 所有消息网关已停止")
+		stopped := 0
+		for _, st := range statuses {
+			if !st.Running {
+				continue
+			}
+			if err := stopMsgGateway(baseURL, st.Name); err != nil {
+				return err
+			}
+			stopped++
+		}
+		if stopped == 0 {
+			fmt.Println("ℹ️ 没有运行中的消息网关")
+			return nil
+		}
+		fmt.Printf("✅ 已停止 %d 个消息网关\n", stopped)
 		return nil
 	}
 
-	if err := gm.Stop(args[0]); err != nil {
+	if err := stopMsgGateway(baseURL, args[0]); err != nil {
 		return err
 	}
 	fmt.Printf("✅ 消息网关 %s 已停止\n", args[0])
@@ -1457,13 +1489,15 @@ func runMsgGatewayStop(cmd *cobra.Command, args []string) error {
 }
 
 func runMsgGatewayStatus(cmd *cobra.Command, args []string) error {
-	a, err := getAgent()
+	baseURL, err := resolveMsgGatewayAPIBase(cmd)
 	if err != nil {
 		return err
 	}
 
-	gm := a.MsgGateway()
-	statuses := gm.Status()
+	statuses, err := fetchMsgGatewayStatuses(baseURL)
+	if err != nil {
+		return fmt.Errorf("无法连接到消息网关 API (%s): %w\n提示: 先运行 `lh msg-gateway start ...`", baseURL, err)
+	}
 
 	if len(statuses) == 0 {
 		fmt.Println("📋 暂无已注册的消息网关")
@@ -1480,6 +1514,86 @@ func runMsgGatewayStatus(cmd *cobra.Command, args []string) error {
 			running, s.Name, s.Stats.MessagesSent, s.Stats.MessagesReceived, s.Stats.Errors)
 	}
 	return nil
+}
+
+func resolveMsgGatewayAPIBase(cmd *cobra.Command) (string, error) {
+	addr, _ := cmd.Flags().GetString("api-addr")
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		mgr, err := config.NewManager()
+		if err != nil {
+			return "", err
+		}
+		if err := mgr.Load(); err != nil {
+			return "", err
+		}
+		addr = strings.TrimSpace(mgr.Get().MsgGateway.APIAddr)
+	}
+	if addr == "" {
+		addr = "127.0.0.1:9090"
+	}
+	if !strings.HasPrefix(addr, "http://") && !strings.HasPrefix(addr, "https://") {
+		addr = "http://" + addr
+	}
+	return strings.TrimRight(addr, "/"), nil
+}
+
+func fetchMsgGatewayStatuses(baseURL string) ([]gateway.GatewayStatus, error) {
+	client := &http.Client{Timeout: 8 * time.Second}
+	req, err := http.NewRequest(http.MethodGet, baseURL+"/api/v1/gateways", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, decodeMsgGatewayAPIError(resp)
+	}
+
+	var data msgGatewayListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, fmt.Errorf("解析网关状态失败: %w", err)
+	}
+	return data.Gateways, nil
+}
+
+func stopMsgGateway(baseURL, name string) error {
+	client := &http.Client{Timeout: 8 * time.Second}
+	reqURL := fmt.Sprintf("%s/api/v1/gateways/%s/stop", baseURL, url.PathEscape(name))
+	req, err := http.NewRequest(http.MethodPost, reqURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return decodeMsgGatewayAPIError(resp)
+	}
+	return nil
+}
+
+func decodeMsgGatewayAPIError(resp *http.Response) error {
+	body, _ := io.ReadAll(resp.Body)
+
+	var apiErr msgGatewayErrorResponse
+	if err := json.Unmarshal(body, &apiErr); err == nil && apiErr.Error != "" {
+		if apiErr.Details != "" {
+			return fmt.Errorf("%s: %s (HTTP %d)", apiErr.Error, apiErr.Details, resp.StatusCode)
+		}
+		return fmt.Errorf("%s (HTTP %d)", apiErr.Error, resp.StatusCode)
+	}
+	if len(body) == 0 {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	return fmt.Errorf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 }
 
 // ===== v0.10.0: Subscription 命令实现 =====

--- a/config.example.json
+++ b/config.example.json
@@ -1,73 +1,105 @@
 {
-  "agents": {
-    "defaults": {
-      "model": "glm-5.1",
-      "provider": "openai",
-      "maxTokens": 102768,
-      "contextWindowTokens": 195536,
-      "temperature": 0.1,
-      "maxToolIterations": 500,
-      "reasoningEffort": null
-    }
+  "provider": "openai",
+  "api_key": "sk-your-api-key",
+  "api_base": "https://api.openai.com/v1",
+  "model": "gpt-4o",
+  "soul_path": "/home/you/.luckyharness/SOUL.md",
+  "max_tokens": 4096,
+  "temperature": 0.7,
+  "extra_headers": {
+    "User-Agent": "luckyharness/0.64.0"
   },
-  "channels": {
-    "feishu": {
-      "allowFrom": [
-        "*"
-      ],
-      "appId": "YOUR_APP_ID_HERE",
-      "appSecret": "YOUR_APP_SECRET_HERE",
-      "enabled": false
-    },
-    "qq": {
-      "allowFrom": [
-        "*"
-      ],
-      "appId": "YOUR_APP_ID_HERE",
-      "appSecret": "YOUR_APP_SECRET_HERE",
-      "enabled": true,
-      "isPrivate": false,
-      "sandbox": true,
-      "secret": "YOUR_SECRET_HERE",
-      "streaming": true
-    },
+  "web_search": {
+    "provider": "brave",
+    "api_key": "",
+    "base_url": "",
+    "max_results": 5,
+    "proxy": ""
+  },
+  "stream_mode": "native",
+  "memory": {
+    "short_term_max_turns": 10,
+    "midterm_expire_days": 365,
+    "midterm_max_summaries": 100
+  },
+  "model_router": {
+    "enable": false,
+    "simple_model": "gpt-4o-mini",
+    "complex_model": "gpt-4o",
+    "local_model": "qwen2.5-coder-32b",
+    "local_base_url": "http://127.0.0.1:11434/v1",
+    "token_threshold": 500
+  },
+  "limits": {
+    "max_tokens": 4096,
+    "temperature": 0.7,
+    "timeout_seconds": 60,
+    "max_timeout_seconds": 600,
+    "max_tool_calls": 5,
+    "max_concurrent_tool_calls": 3
+  },
+  "retry": {
+    "enabled": true,
+    "max_attempts": 3,
+    "initial_delay_ms": 1000,
+    "max_delay_ms": 10000,
+    "retry_on_rate_limit": true,
+    "retry_on_timeout": true,
+    "retry_on_server_error": true
+  },
+  "circuit_breaker": {
+    "enabled": false,
+    "error_threshold": 5,
+    "window_seconds": 60,
+    "timeout_seconds": 30,
+    "half_open_max_requests": 1
+  },
+  "rate_limit": {
+    "enabled": true,
+    "requests_per_minute": 60,
+    "tokens_per_minute": 100000,
+    "burst_size": 10
+  },
+  "context": {
+    "max_history_turns": 50,
+    "max_context_tokens": 8000,
+    "compression_threshold": 0.8
+  },
+  "agent": {
+    "max_iterations": 10,
+    "timeout_seconds": 60,
+    "auto_approve": false
+  },
+  "server": {
+    "addr": "127.0.0.1:9090",
+    "api_keys": [],
+    "enable_cors": true,
+    "cors_origins": [
+      "*"
+    ],
+    "rate_limit": 60,
+    "metrics_addr": "",
+    "log_level": "info",
+    "log_format": "text"
+  },
+  "dashboard": {
+    "addr": ":8765"
+  },
+  "msg_gateway": {
+    "platform": "telegram",
+    "start_all": false,
+    "api_addr": "127.0.0.1:9090",
     "telegram": {
-      "allowFrom": [
-        "*"
-      ],
-      "connectionPoolSize": 32,
-      "enabled": true,
-      "groupPolicy": "mention",
-      "poolTimeout": 5,
-      "privacy_mode": false,
-      "proxy": null,
-      "reactEmoji": "\ud83d\udc40",
-      "replyToMessage": false,
-      "streamEditInterval": 0.6,
-      "streaming": true,
-      "token": "YOUR_TOKEN_HERE",
-      "model": "glm-5.1",
-      "api_base": "http://maas.icompify.com:32788/v1",
-      "api_key": "YOUR_API_KEY_HERE"
+      "token": ""
+    },
+    "onebot": {
+      "api_base": "",
+      "ws_url": "",
+      "access_token": "",
+      "bot_id": "",
+      "show_typing": true,
+      "auto_like": true,
+      "like_times": 1
     }
-  },
-  "providers": {
-    "openai": {
-      "apiKey": "YOUR_API_KEY_HERE",
-      "apiBase": "http://maas.icompify.com:32788/v1",
-      "extraHeaders": {
-        "User-Agent": "nanobot/1.0",
-        "X-Stainless-Arch": "x",
-        "X-Stainless-Lang": "x",
-        "X-Stainless-Os": "x",
-        "X-Stainless-Package-Version": "x",
-        "X-Stainless-Runtime": "x",
-        "X-Stainless-Runtime-Version": "x"
-      }
-    }
-  },
-  "gateway": {
-    "host": "0.0.0.0",
-    "port": 18790
   }
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,251 +1,47 @@
-# LuckyHarness 配置指南 v0.56.0
+# LuckyHarness 配置指南 v0.64.0
 
-## 📋 完整配置示例
+## 配置文件位置
 
-```json
-{
-  "provider": "openai",
-  "api_key": "sk-your-api-key",
-  "api_base": "https://api.boaiak.com/v1",
-  "model": "gpt-5.4-mini",
-  "soul_path": "/root/.luckyharness/SOUL.md",
-  
-  "limits": {
-    "max_tokens": 4096,
-    "temperature": 0.7,
-    "timeout_seconds": 60,
-    "max_timeout_seconds": 600,
-    "max_tool_calls": 5,
-    "max_concurrent_tool_calls": 3
-  },
-  
-  "retry": {
-    "enabled": true,
-    "max_attempts": 3,
-    "initial_delay_ms": 1000,
-    "max_delay_ms": 10000,
-    "retry_on_rate_limit": true,
-    "retry_on_timeout": true,
-    "retry_on_server_error": true
-  },
-  
-  "circuit_breaker": {
-    "enabled": false,
-    "error_threshold": 5,
-    "window_seconds": 60,
-    "timeout_seconds": 30,
-    "half_open_max_requests": 1
-  },
-  
-  "rate_limit": {
-    "enabled": true,
-    "requests_per_minute": 60,
-    "tokens_per_minute": 100000,
-    "burst_size": 10
-  },
-  
-  "memory": {
-    "short_term_max_turns": 10,
-    "midterm_expire_days": 90,
-    "midterm_max_summaries": 100
-  },
-  
-  "context": {
-    "max_history_turns": 50,
-    "max_context_tokens": 8000,
-    "compression_threshold": 0.8
-  }
-}
-```
+统一使用一个配置文件：
 
-## 🔧 配置项说明
+`~/.luckyharness/config.json`
 
-### 基础配置
+程序启动时会加载这个文件，未显式传 CLI 参数时使用这里的值。
 
-| 字段 | 说明 | 默认值 |
-|------|------|--------|
-| `provider` | Provider 类型 | `openai` |
-| `api_key` | API 密钥 | 必填 |
-| `api_base` | API 基础 URL | `https://api.openai.com/v1` |
-| `model` | 模型名称 | `gpt-4o` |
-| `soul_path` | 角色配置文件路径 | - |
+## 完整示例
 
-### 限制配置 (`limits`)
+请直接参考仓库根目录：
 
-| 字段 | 说明 | 默认值 |
-|------|------|--------|
-| `max_tokens` | 最大生成 token 数 | 4096 |
-| `temperature` | 温度参数 | 0.7 |
-| `timeout_seconds` | 单次调用超时（秒） | 60 |
-| `max_timeout_seconds` | 最大允许超时（秒） | 600 |
-| `max_tool_calls` | 单次响应最大工具调用数 | 5 |
-| `max_concurrent_tool_calls` | 最大并发工具调用数 | 3 |
+`config.example.json`
 
-### 重试配置 (`retry`)
+## 启动命令与配置映射
 
-| 字段 | 说明 | 默认值 |
-|------|------|--------|
-| `enabled` | 是否启用重试 | `true` |
-| `max_attempts` | 最大重试次数 | 3 |
-| `initial_delay_ms` | 初始重试延迟（毫秒） | 1000 |
-| `max_delay_ms` | 最大重试延迟（毫秒） | 10000 |
-| `retry_on_rate_limit` | 429 错误重试 | `true` |
-| `retry_on_timeout` | 超时重试 | `true` |
-| `retry_on_server_error` | 5xx 错误重试 | `true` |
+- `lh chat` 读取：`provider/api_key/api_base/model/soul_path/max_tokens/temperature` 和 `agent.*`
+- `lh serve` 读取：`server.*`
+- `lh dashboard start` 读取：`dashboard.addr`
+- `lh msg-gateway start` 读取：`msg_gateway.*`
 
-### 熔断器配置 (`circuit_breaker`)
+说明：
 
-| 字段 | 说明 | 默认值 |
-|------|------|--------|
-| `enabled` | 是否启用熔断器 | `false` |
-| `error_threshold` | 错误次数阈值 | 5 |
-| `window_seconds` | 错误统计窗口（秒） | 60 |
-| `timeout_seconds` | 熔断超时（秒） | 30 |
-| `half_open_max_requests` | 半开状态最大请求数 | 1 |
+- CLI 参数优先级高于 `config.json`。
+- 未传 CLI 参数时，启动命令会自动回落到 `config.json`。
 
-### 限流配置 (`rate_limit`)
+## 常用字段
 
-| 字段 | 说明 | 默认值 |
-|------|------|--------|
-| `enabled` | 是否启用限流 | `true` |
-| `requests_per_minute` | 每分钟最大请求数 | 60 |
-| `tokens_per_minute` | 每分钟最大 token 数 | 100000 |
-| `burst_size` | 突发请求数 | 10 |
+- LLM 主配置：`provider`, `api_key`, `api_base`, `model`, `max_tokens`, `temperature`
+- Provider 额外请求头：`extra_headers`
+- 重试/熔断/限流：`retry`, `circuit_breaker`, `rate_limit`
+- Agent Loop：`agent.max_iterations`, `agent.timeout_seconds`, `agent.auto_approve`
+- API Server：`server.addr`, `server.api_keys`, `server.enable_cors`, `server.rate_limit`
+- 消息网关：`msg_gateway.platform`, `msg_gateway.telegram.token`, `msg_gateway.onebot.*`
 
-### 内存配置 (`memory`)
+## 生效方式
 
-| 字段 | 说明 | 默认值 |
-|------|------|--------|
-| `short_term_max_turns` | 短期记忆最大轮数 | 10 |
-| `midterm_expire_days` | 中期记忆过期天数 | 90 |
-| `midterm_max_summaries` | 中期记忆最大摘要数 | 100 |
+编辑 `config.json` 后重启对应进程即可生效。
 
-### 上下文配置 (`context`)
-
-| 字段 | 说明 | 默认值 |
-|------|------|--------|
-| `max_history_turns` | 最大历史对话轮数 | 50 |
-| `max_context_tokens` | 最大上下文 token 数 | 8000 |
-| `compression_threshold` | 压缩阈值 | 0.8 |
-
-## 🚀 使用方式
-
-### 1. 编辑配置文件
-
-```bash
-nano /root/.luckyharness/config.json
-```
-
-### 2. 重启 LuckyHarness
+示例：
 
 ```bash
 pkill -9 lh
-cd /root/.luckyharness
-./lh msg-gateway start --platform telegram --token YOUR_TOKEN
-```
-
-### 3. 验证配置
-
-```bash
-curl http://localhost:9090/api/v1/health
-```
-
-## 📝 配置优先级
-
-1. **配置文件** (`config.json`) - 最高优先级
-2. **环境变量** - 次优先级
-3. **代码默认值** - 最低优先级
-
-## ⚠️ 注意事项
-
-- `max_tokens` 不能超过模型的最大上下文窗口
-- `timeout_seconds` 应该小于 `max_timeout_seconds`
-- `max_attempts` 设置过大会增加延迟
-- 熔断器和限流可以同时启用
-- 生产环境建议启用熔断器
-
-## 🔍 故障排查
-
-### 查看当前配置
-
-```bash
-cat /root/.luckyharness/config.json | python3 -m json.tool
-```
-
-### 测试配置是否生效
-
-```bash
-# 发送测试消息
-curl -X POST http://localhost:9090/api/v1/chat \
-  -H "Content-Type: application/json" \
-  -d '{"message": "test"}'
-```
-
-### 查看日志
-
-```bash
-tail -f /tmp/lh-*.log
-```
-
-## 📊 推荐配置
-
-### 开发环境
-
-```json
-{
-  "limits": {
-    "max_tokens": 2048,
-    "timeout_seconds": 30
-  },
-  "retry": {
-    "max_attempts": 2
-  },
-  "rate_limit": {
-    "requests_per_minute": 30
-  }
-}
-```
-
-### 生产环境
-
-```json
-{
-  "limits": {
-    "max_tokens": 4096,
-    "timeout_seconds": 60
-  },
-  "retry": {
-    "max_attempts": 3
-  },
-  "circuit_breaker": {
-    "enabled": true,
-    "error_threshold": 5
-  },
-  "rate_limit": {
-    "requests_per_minute": 60
-  }
-}
-```
-
-### 高并发环境
-
-```json
-{
-  "limits": {
-    "max_tokens": 8192,
-    "timeout_seconds": 120,
-    "max_tool_calls": 10
-  },
-  "retry": {
-    "max_attempts": 5
-  },
-  "circuit_breaker": {
-    "enabled": true,
-    "error_threshold": 10
-  },
-  "rate_limit": {
-    "requests_per_minute": 120,
-    "burst_size": 20
-  }
-}
+lh serve
 ```

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -130,6 +130,41 @@ func New(cfg *config.Manager) (*Agent, error) {
 			Model:       c.Model,
 			MaxTokens:   c.MaxTokens,
 			Temperature: c.Temperature,
+			Limits: provider.LimitsConfig{
+				MaxTokens:              c.Limits.MaxTokens,
+				Temperature:            c.Limits.Temperature,
+				TimeoutSeconds:         c.Limits.TimeoutSeconds,
+				MaxTimeoutSeconds:      c.Limits.MaxTimeoutSeconds,
+				MaxToolCalls:           c.Limits.MaxToolCalls,
+				MaxConcurrentToolCalls: c.Limits.MaxConcurrentToolCalls,
+			},
+			Retry: provider.RetryConfig{
+				Enabled:            c.Retry.Enabled,
+				MaxAttempts:        c.Retry.MaxAttempts,
+				InitialDelayMs:     c.Retry.InitialDelayMs,
+				MaxDelayMs:         c.Retry.MaxDelayMs,
+				RetryOnRateLimit:   c.Retry.RetryOnRateLimit,
+				RetryOnTimeout:     c.Retry.RetryOnTimeout,
+				RetryOnServerError: c.Retry.RetryOnServerError,
+			},
+			CircuitBreaker: provider.CircuitBreakerConfig{
+				Enabled:         c.CircuitBreaker.Enabled,
+				ErrorThreshold:  c.CircuitBreaker.ErrorThreshold,
+				WindowSeconds:   c.CircuitBreaker.WindowSeconds,
+				TimeoutSeconds:  c.CircuitBreaker.TimeoutSeconds,
+				HalfOpenMaxReqs: c.CircuitBreaker.HalfOpenMaxReqs,
+			},
+			RateLimit: provider.RateLimitConfig{
+				Enabled:           c.RateLimit.Enabled,
+				RequestsPerMinute: c.RateLimit.RequestsPerMinute,
+				TokensPerMinute:   c.RateLimit.TokensPerMinute,
+				BurstSize:         c.RateLimit.BurstSize,
+			},
+			Context: provider.ContextConfig{
+				MaxHistoryTurns:      c.Context.MaxHistoryTurns,
+				MaxContextTokens:     c.Context.MaxContextTokens,
+				CompressionThreshold: c.Context.CompressionThreshold,
+			},
 		}
 		p, err = registry.Resolve(pCfg)
 		if err != nil {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -124,12 +124,13 @@ func New(cfg *config.Manager) (*Agent, error) {
 	} else {
 		// 单 provider 模式
 		pCfg := provider.Config{
-			Name:        c.Provider,
-			APIKey:      c.APIKey,
-			APIBase:     c.APIBase,
-			Model:       c.Model,
-			MaxTokens:   c.MaxTokens,
-			Temperature: c.Temperature,
+			Name:         c.Provider,
+			APIKey:       c.APIKey,
+			APIBase:      c.APIBase,
+			Model:        c.Model,
+			MaxTokens:    c.MaxTokens,
+			Temperature:  c.Temperature,
+			ExtraHeaders: c.ExtraHeaders,
 			Limits: provider.LimitsConfig{
 				MaxTokens:              c.Limits.MaxTokens,
 				Temperature:            c.Limits.Temperature,
@@ -1850,18 +1851,36 @@ func (a *Agent) fromContextMessages(messages []contextx.Message) []provider.Mess
 
 // applyWebSearchEnv 从环境变量覆盖 web_search 配置
 func applyWebSearchEnv(cfg *config.Manager) {
-	envMap := map[string]string{
-		"LH_WEB_SEARCH_PROVIDER":    "web_search.provider",
-		"LH_WEB_SEARCH_API_KEY":     "web_search.api_key",
-		"LH_WEB_SEARCH_BASE_URL":    "web_search.base_url",
-		"LH_WEB_SEARCH_MAX_RESULTS": "web_search.max_results",
-		"LH_WEB_SEARCH_PROXY":       "web_search.proxy",
-		"BRAVE_API_KEY":             "web_search.api_key",
-		"SEARXNG_BASE_URL":          "web_search.base_url",
+	cur := cfg.Get()
+
+	// 配置文件优先：仅在 config.json 对应字段为空时，才用环境变量补全。
+	if cur.WebSearch.Provider == "" {
+		if v := os.Getenv("LH_WEB_SEARCH_PROVIDER"); v != "" {
+			_ = cfg.Set("web_search.provider", v)
+		}
 	}
-	for envKey, cfgKey := range envMap {
-		if v := os.Getenv(envKey); v != "" {
-			cfg.Set(cfgKey, v)
+	if cur.WebSearch.APIKey == "" {
+		if v := os.Getenv("LH_WEB_SEARCH_API_KEY"); v != "" {
+			_ = cfg.Set("web_search.api_key", v)
+		} else if v := os.Getenv("BRAVE_API_KEY"); v != "" {
+			_ = cfg.Set("web_search.api_key", v)
+		}
+	}
+	if cur.WebSearch.BaseURL == "" {
+		if v := os.Getenv("LH_WEB_SEARCH_BASE_URL"); v != "" {
+			_ = cfg.Set("web_search.base_url", v)
+		} else if v := os.Getenv("SEARXNG_BASE_URL"); v != "" {
+			_ = cfg.Set("web_search.base_url", v)
+		}
+	}
+	if cur.WebSearch.MaxResults <= 0 {
+		if v := os.Getenv("LH_WEB_SEARCH_MAX_RESULTS"); v != "" {
+			_ = cfg.Set("web_search.max_results", v)
+		}
+	}
+	if cur.WebSearch.Proxy == "" {
+		if v := os.Getenv("LH_WEB_SEARCH_PROXY"); v != "" {
+			_ = cfg.Set("web_search.proxy", v)
 		}
 	}
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -29,34 +29,34 @@ import (
 
 // Agent 是 LuckyHarness 的核心 Agent
 type Agent struct {
-	cfg          *config.Manager
-	soul         *soul.Soul
-	tmplMgr      *soul.TemplateManager // v0.19.0: SOUL 模板管理器
-	provider     provider.Provider       // 当前活跃 provider (可能是 FallbackChain)
-	registry     *provider.Registry     // provider 注册表
-	catalog      *provider.ModelCatalog  // 模型目录
-	tokenStore   *provider.TokenStore    // token 存储
-	memory       *memory.Store
-	shortTerm    *memory.ShortTermBuffer // v0.43.0: 短期记忆滑动窗口
-	midTerm      *memory.MidTermStore    // v0.43.0: 中期会话摘要存储
-	sessions     *session.Manager
-	tools        *tool.Registry
-	gateway      *tool.Gateway          // 统一工具网关
-	msgGateway   *gateway.GatewayManager // v0.6.0: 消息平台网关
-	mcpClient    *tool.MCPClient         // MCP 客户端
-	delegate     *tool.DelegateManager   // 子代理委派管理器
-	contextWin   *contextx.ContextWindow // 上下文窗口管理器
-	ragManager   *rag.RAGManager         // RAG 知识库管理器
-	ragPersist   *rag.Persistence        // RAG 持久化
-	streamIndexer *rag.StreamIndexer     // v0.23.0: 流式索引器
-	embedderReg  *embedder.Registry      // v0.21.0: 嵌入模型注册表
-	collabReg    *collab.Registry        // v0.22.0: Agent 协作注册表
-	collabMgr    *collab.DelegateManager // v0.22.0: 协作任务管理器
-	skills       []*tool.SkillInfo       // v0.35.0: 已加载的 skill 列表
-	metrics      *metrics.Metrics        // v0.36.0: 指标收集器
-	cronEngine   *cron.Engine            // v0.36.0: 定时任务引擎
-	autonomy     *autonomy.AutonomyKit   // v0.38.0: 自主工作套件
-	chatCount    int // 对话计数，用于触发自动摘要
+	cfg           *config.Manager
+	soul          *soul.Soul
+	tmplMgr       *soul.TemplateManager  // v0.19.0: SOUL 模板管理器
+	provider      provider.Provider      // 当前活跃 provider (可能是 FallbackChain)
+	registry      *provider.Registry     // provider 注册表
+	catalog       *provider.ModelCatalog // 模型目录
+	tokenStore    *provider.TokenStore   // token 存储
+	memory        *memory.Store
+	shortTerm     *memory.ShortTermBuffer // v0.43.0: 短期记忆滑动窗口
+	midTerm       *memory.MidTermStore    // v0.43.0: 中期会话摘要存储
+	sessions      *session.Manager
+	tools         *tool.Registry
+	gateway       *tool.Gateway           // 统一工具网关
+	msgGateway    *gateway.GatewayManager // v0.6.0: 消息平台网关
+	mcpClient     *tool.MCPClient         // MCP 客户端
+	delegate      *tool.DelegateManager   // 子代理委派管理器
+	contextWin    *contextx.ContextWindow // 上下文窗口管理器
+	ragManager    *rag.RAGManager         // RAG 知识库管理器
+	ragPersist    *rag.Persistence        // RAG 持久化
+	streamIndexer *rag.StreamIndexer      // v0.23.0: 流式索引器
+	embedderReg   *embedder.Registry      // v0.21.0: 嵌入模型注册表
+	collabReg     *collab.Registry        // v0.22.0: Agent 协作注册表
+	collabMgr     *collab.DelegateManager // v0.22.0: 协作任务管理器
+	skills        []*tool.SkillInfo       // v0.35.0: 已加载的 skill 列表
+	metrics       *metrics.Metrics        // v0.36.0: 指标收集器
+	cronEngine    *cron.Engine            // v0.36.0: 定时任务引擎
+	autonomy      *autonomy.AutonomyKit   // v0.38.0: 自主工作套件
+	chatCount     int                     // 对话计数，用于触发自动摘要
 }
 
 // New 创建 Agent
@@ -192,12 +192,12 @@ func New(cfg *config.Manager) (*Agent, error) {
 	// 创建上下文窗口管理器
 	contextWin := contextx.NewContextWindow(contextx.WindowConfig{
 		MaxTokens:            c.MaxTokens,
-		ReservedTokens:      c.MaxTokens / 4, // 为回复预留 1/4
+		ReservedTokens:       c.MaxTokens / 4, // 为回复预留 1/4
 		Strategy:             contextx.TrimLowPriority,
 		SlidingWindowSize:    10,
 		MaxConversationTurns: 50,
 		MemoryBudget:         800,
-		SummarizeThreshold:  0.8,
+		SummarizeThreshold:   0.8,
 	})
 
 	// 创建 RAG 知识库管理器
@@ -373,32 +373,32 @@ func New(cfg *config.Manager) (*Agent, error) {
 	})
 
 	a := &Agent{
-		cfg:        cfg,
-		soul:       s,
-		tmplMgr:    tmplMgr,
-		provider:   p,
-		registry:   registry,
-		catalog:    catalog,
-		tokenStore: tokenStore,
-		memory:     mem,
-		shortTerm:  shortTerm,
-		midTerm:    midTerm,
-		sessions:   sessions,
-		tools:      tools,
-		gateway:    toolGateway,
-		msgGateway: gateway.NewGatewayManager(),
-		mcpClient:  mcpClient,
-		delegate:   delegateMgr,
-		contextWin: contextWin,
-		ragManager:  ragManager,
-		ragPersist:  ragPersist,
+		cfg:           cfg,
+		soul:          s,
+		tmplMgr:       tmplMgr,
+		provider:      p,
+		registry:      registry,
+		catalog:       catalog,
+		tokenStore:    tokenStore,
+		memory:        mem,
+		shortTerm:     shortTerm,
+		midTerm:       midTerm,
+		sessions:      sessions,
+		tools:         tools,
+		gateway:       toolGateway,
+		msgGateway:    gateway.NewGatewayManager(),
+		mcpClient:     mcpClient,
+		delegate:      delegateMgr,
+		contextWin:    contextWin,
+		ragManager:    ragManager,
+		ragPersist:    ragPersist,
 		streamIndexer: streamIndexer,
-		embedderReg: embedderReg,
-		collabReg:   collabReg,
-		collabMgr:   collabMgr,
-		metrics:     m,
-		cronEngine:  cronEngine,
-		autonomy:    autonomyKit,
+		embedderReg:   embedderReg,
+		collabReg:     collabReg,
+		collabMgr:     collabMgr,
+		metrics:       m,
+		cronEngine:    cronEngine,
+		autonomy:      autonomyKit,
 	}
 
 	// v0.35.0: 自动加载 skills 目录
@@ -618,12 +618,12 @@ type ChatEvent struct {
 type ChatEventType int
 
 const (
-	ChatEventThinking  ChatEventType = iota // 🧠 思考中
-	ChatEventToolCall                       // 🔧 工具调用
-	ChatEventToolResult                     // 📋 工具结果
-	ChatEventContent                        // 📝 内容片段
-	ChatEventDone                           // ✅ 完成
-	ChatEventError                          // ❌ 错误
+	ChatEventThinking   ChatEventType = iota // 🧠 思考中
+	ChatEventToolCall                        // 🔧 工具调用
+	ChatEventToolResult                      // 📋 工具结果
+	ChatEventContent                         // 📝 内容片段
+	ChatEventDone                            // ✅ 完成
+	ChatEventError                           // ❌ 错误
 )
 
 // StreamMode 流式输出模式
@@ -687,24 +687,18 @@ func (a *Agent) ChatWithSessionStream(ctx context.Context, sessionID string, use
 		loopCfg := DefaultLoopConfig()
 		loopCfg.AutoApprove = true
 
-		for i := 0; i < loopCfg.MaxIterations; i++ {
-			// 🧠 思考阶段
-			events <- ChatEvent{Type: ChatEventThinking, Content: fmt.Sprintf("Thinking... (round %d)", i+1)}
+		// 🧠 思考阶段（第一轮）
+		events <- ChatEvent{Type: ChatEventThinking, Content: "Thinking... (round 1)"}
 
-			mode := a.getStreamMode()
-
-			if mode == StreamModeNative {
-				// === 真流式路径 ===
-				a.streamNative(ctx, events, messages, callOpts, sess, userInput, i)
-				return
-			}
-
-			// === 模拟流式路径 ===
-			a.streamSimulated(ctx, events, messages, callOpts, sess, userInput)
+		mode := a.getStreamMode()
+		if mode == StreamModeNative {
+			// === 真流式路径 ===
+			a.streamNative(ctx, events, messages, callOpts, sess, userInput, 1, loopCfg.MaxIterations)
 			return
 		}
 
-		events <- ChatEvent{Type: ChatEventError, Err: fmt.Errorf("max iterations reached")}
+		// === 模拟流式路径 ===
+		a.streamSimulated(ctx, events, messages, callOpts, sess, userInput, 1, loopCfg.MaxIterations)
 	}()
 
 	return events, nil
@@ -712,7 +706,12 @@ func (a *Agent) ChatWithSessionStream(ctx context.Context, sessionID string, use
 
 // streamNative 真流式：直接使用 provider 的 ChatStream，逐 chunk 推送
 // tool_calls 通过流式增量拼接处理
-func (a *Agent) streamNative(ctx context.Context, events chan<- ChatEvent, messages []provider.Message, callOpts provider.CallOptions, sess *session.Session, userInput string, round int) {
+func (a *Agent) streamNative(ctx context.Context, events chan<- ChatEvent, messages []provider.Message, callOpts provider.CallOptions, sess *session.Session, userInput string, round int, remaining int) {
+	if remaining <= 0 {
+		events <- ChatEvent{Type: ChatEventError, Err: fmt.Errorf("max iterations reached")}
+		return
+	}
+
 	// 尝试流式调用
 	var ch <-chan provider.StreamChunk
 	var err error
@@ -883,10 +882,15 @@ func (a *Agent) streamNative(ctx context.Context, events chan<- ChatEvent, messa
 
 			// 裁剪上下文，继续下一轮
 			messages = a.fitContextWindow(messages)
-			events <- ChatEvent{Type: ChatEventThinking, Content: fmt.Sprintf("Thinking... (round %d)", round+2)}
+			if remaining <= 1 {
+				events <- ChatEvent{Type: ChatEventError, Err: fmt.Errorf("max iterations reached")}
+				return
+			}
+			nextRound := round + 1
+			events <- ChatEvent{Type: ChatEventThinking, Content: fmt.Sprintf("Thinking... (round %d)", nextRound)}
 
 			// 递归进入下一轮（用非流式，因为 tool_calls 后通常需要完整响应）
-			a.streamSimulated(ctx, events, messages, callOpts, sess, userInput)
+			a.streamSimulated(ctx, events, messages, callOpts, sess, userInput, nextRound, remaining-1)
 			return
 		}
 	}
@@ -896,7 +900,8 @@ func (a *Agent) streamNative(ctx context.Context, events chan<- ChatEvent, messa
 
 	// 如果流式没产出内容，回退到非流式
 	if response == "" {
-		a.streamSimulated(ctx, events, messages, callOpts, sess, userInput)
+		// 同一轮回退，不消耗额外迭代次数
+		a.streamSimulated(ctx, events, messages, callOpts, sess, userInput, round, remaining)
 		return
 	}
 
@@ -904,7 +909,12 @@ func (a *Agent) streamNative(ctx context.Context, events chan<- ChatEvent, messa
 }
 
 // streamSimulated 模拟流式：先非流式获取完整响应，再按句子边界逐段推送
-func (a *Agent) streamSimulated(ctx context.Context, events chan<- ChatEvent, messages []provider.Message, callOpts provider.CallOptions, sess *session.Session, userInput string) {
+func (a *Agent) streamSimulated(ctx context.Context, events chan<- ChatEvent, messages []provider.Message, callOpts provider.CallOptions, sess *session.Session, userInput string, round int, remaining int) {
+	if remaining <= 0 {
+		events <- ChatEvent{Type: ChatEventError, Err: fmt.Errorf("max iterations reached")}
+		return
+	}
+
 	var resp *provider.Response
 	var err error
 	if fcProvider, ok := a.provider.(provider.FunctionCallingProvider); ok && len(callOpts.Tools) > 0 {
@@ -1022,8 +1032,13 @@ func (a *Agent) streamSimulated(ctx context.Context, events chan<- ChatEvent, me
 
 		// 裁剪上下文，递归继续
 		messages = a.fitContextWindow(messages)
-		events <- ChatEvent{Type: ChatEventThinking, Content: "Continuing..."}
-		a.streamSimulated(ctx, events, messages, callOpts, sess, userInput)
+		if remaining <= 1 {
+			events <- ChatEvent{Type: ChatEventError, Err: fmt.Errorf("max iterations reached")}
+			return
+		}
+		nextRound := round + 1
+		events <- ChatEvent{Type: ChatEventThinking, Content: fmt.Sprintf("Thinking... (round %d)", nextRound)}
+		a.streamSimulated(ctx, events, messages, callOpts, sess, userInput, nextRound, remaining-1)
 		return
 	}
 
@@ -1778,7 +1793,7 @@ func (a *Agent) toContextMessages(messages []provider.Message) []contextx.Messag
 		result[i] = contextx.Message{
 			Role:      msg.Role,
 			Content:   msg.Content,
-			Priority: priority,
+			Priority:  priority,
 			Category:  category,
 			Timestamp: time.Now(),
 		}

--- a/internal/agent/agent_integration_test.go
+++ b/internal/agent/agent_integration_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -21,9 +22,9 @@ func TestAgentChatWithMockProvider(t *testing.T) {
 
 	// 设置期望：Chat 被调用一次，返回预设响应
 	expectedResp := &provider.Response{
-		Content: "Hello from mock provider!",
+		Content:    "Hello from mock provider!",
 		TokensUsed: 30,
-		Model: "gpt-3.5-turbo",
+		Model:      "gpt-3.5-turbo",
 	}
 	mockProvider.EXPECT().
 		Chat(gomock.Any(), gomock.Any()).
@@ -70,9 +71,9 @@ func TestAgentChatWithMockProviderError(t *testing.T) {
 
 	// 设置期望：Chat 被调用（RunLoop 回退到 chatStreamSimple 时会调用）
 	expectedResp := &provider.Response{
-		Content: "Fallback response",
+		Content:    "Fallback response",
 		TokensUsed: 20,
-		Model: "gpt-3.5-turbo",
+		Model:      "gpt-3.5-turbo",
 	}
 	mockProvider.EXPECT().
 		Chat(gomock.Any(), gomock.Any()).
@@ -201,9 +202,9 @@ func TestAgentChatWithSessionMockProvider(t *testing.T) {
 	mockProvider := mocks.NewMockProvider(ctrl)
 
 	expectedResp := &provider.Response{
-		Content: "Session response",
+		Content:    "Session response",
 		TokensUsed: 40,
-		Model: "gpt-3.5-turbo",
+		Model:      "gpt-3.5-turbo",
 	}
 	mockProvider.EXPECT().
 		Chat(gomock.Any(), gomock.Any()).
@@ -292,5 +293,76 @@ func TestAgentChatWithSessionStreamMockProvider(t *testing.T) {
 	// 验证至少收到一些事件
 	if len(events) == 0 {
 		t.Error("ChatWithSessionStream() returned no events")
+	}
+}
+
+// TestAgentChatWithSessionStreamRespectsMaxIterations 验证流式路径不会无限递归
+func TestAgentChatWithSessionStreamRespectsMaxIterations(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockProvider := mocks.NewMockProvider(ctrl)
+
+	// 第一轮（native stream）返回 tool call，触发进入 simulated 路径
+	streamChan := make(chan provider.StreamChunk, 2)
+	streamChan <- provider.StreamChunk{
+		ToolCallDeltas: []provider.StreamToolCallDelta{
+			{
+				Index:     0,
+				ID:        "call_stream_1",
+				Name:      "missing_tool",
+				Arguments: "{}",
+			},
+		},
+	}
+	streamChan <- provider.StreamChunk{Done: true}
+	close(streamChan)
+
+	mockProvider.EXPECT().
+		ChatStream(gomock.Any(), gomock.Any()).
+		Return(streamChan, nil).
+		Times(1)
+
+	// 后续 simulated 路径持续返回 tool call，直到触发 max iterations
+	loopResp := &provider.Response{
+		Content: "",
+		ToolCalls: []provider.ToolCall{
+			{ID: "call_loop", Name: "missing_tool", Arguments: "{}"},
+		},
+	}
+	mockProvider.EXPECT().
+		Chat(gomock.Any(), gomock.Any()).
+		Return(loopResp, nil).
+		AnyTimes()
+
+	tmpDir := t.TempDir()
+	cfg, _ := config.NewManagerWithDir(tmpDir)
+	cfg.Set("provider", "openai")
+	cfg.Set("api_key", "sk-test")
+	cfg.Set("model", "gpt-3.5-turbo")
+	cfg.Set("stream_mode", "native")
+
+	a, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	a.provider = mockProvider
+
+	sessionID := a.sessions.New().ID
+	eventChan, err := a.ChatWithSessionStream(context.Background(), sessionID, "loop test")
+	if err != nil {
+		t.Fatalf("ChatWithSessionStream() error = %v", err)
+	}
+
+	foundMaxIterationErr := false
+	for event := range eventChan {
+		if event.Type == ChatEventError && event.Err != nil &&
+			strings.Contains(event.Err.Error(), "max iterations reached") {
+			foundMaxIterationErr = true
+		}
+	}
+
+	if !foundMaxIterationErr {
+		t.Fatal("expected max iterations reached error event")
 	}
 }

--- a/internal/agent/agent_integration_test.go
+++ b/internal/agent/agent_integration_test.go
@@ -3,8 +3,10 @@ package agent
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/yurika0211/luckyharness/internal/config"
@@ -364,5 +366,102 @@ func TestAgentChatWithSessionStreamRespectsMaxIterations(t *testing.T) {
 
 	if !foundMaxIterationErr {
 		t.Fatal("expected max iterations reached error event")
+	}
+}
+
+func TestRunLoopStopsRepeatedToolCallLoop(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockProvider := mocks.NewMockProvider(ctrl)
+	loopResp := &provider.Response{
+		Content: "",
+		ToolCalls: []provider.ToolCall{
+			{ID: "call_repeat", Name: "missing_tool", Arguments: "{}"},
+		},
+	}
+	mockProvider.EXPECT().
+		Chat(gomock.Any(), gomock.Any()).
+		Return(loopResp, nil).
+		AnyTimes()
+
+	tmpDir := t.TempDir()
+	cfg, _ := config.NewManagerWithDir(tmpDir)
+	cfg.Set("provider", "openai")
+	cfg.Set("api_key", "sk-test")
+	cfg.Set("model", "gpt-3.5-turbo")
+
+	a, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	a.provider = mockProvider
+
+	loopCfg := DefaultLoopConfig()
+	loopCfg.MaxIterations = 8
+	loopCfg.Timeout = 2 * time.Second
+
+	result, err := a.RunLoop(context.Background(), "repeat tool loop", loopCfg)
+	if err != nil {
+		t.Fatalf("RunLoop() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("RunLoop() returned nil result")
+	}
+	if result.Iterations != 3 {
+		t.Fatalf("expected 3 iterations before short-circuit, got %d", result.Iterations)
+	}
+	if !strings.Contains(result.Response, "Detected repeated tool-call loop") {
+		t.Fatalf("expected loop guard response, got: %q", result.Response)
+	}
+	if len(result.ToolCalls) != 2 {
+		t.Fatalf("expected 2 executed tool calls before guard triggered, got %d", len(result.ToolCalls))
+	}
+}
+
+func TestRunLoopStopsConsecutiveToolOnlyIterations(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockProvider := mocks.NewMockProvider(ctrl)
+	callN := 0
+	mockProvider.EXPECT().
+		Chat(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ []provider.Message) (*provider.Response, error) {
+			callN++
+			return &provider.Response{
+				Content: "",
+				ToolCalls: []provider.ToolCall{
+					{ID: fmt.Sprintf("call_%d", callN), Name: "missing_tool", Arguments: fmt.Sprintf("{\"n\":%d}", callN)},
+				},
+			}, nil
+		}).
+		AnyTimes()
+
+	tmpDir := t.TempDir()
+	cfg, _ := config.NewManagerWithDir(tmpDir)
+	cfg.Set("provider", "openai")
+	cfg.Set("api_key", "sk-test")
+	cfg.Set("model", "gpt-3.5-turbo")
+
+	a, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	a.provider = mockProvider
+
+	loopCfg := DefaultLoopConfig()
+	loopCfg.MaxIterations = 8
+	loopCfg.Timeout = 2 * time.Second
+
+	result, err := a.RunLoop(context.Background(), "tool-only loop", loopCfg)
+	if err != nil {
+		t.Fatalf("RunLoop() error = %v", err)
+	}
+	if result.Iterations != 3 {
+		t.Fatalf("expected 3 iterations before consecutive-tool guard, got %d", result.Iterations)
+	}
+	if !strings.Contains(result.Response, "Detected repeated tool-call loop") {
+		t.Fatalf("expected loop guard response, got: %q", result.Response)
 	}
 }

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -113,6 +113,12 @@ func (a *Agent) RunLoopWithSession(ctx context.Context, sess *session.Session, u
 	result := &LoopResult{
 		State: StateReason,
 	}
+	toolCallRepeatCount := make(map[string]int)
+	toolCallLastResult := make(map[string]string)
+	consecutiveToolOnlyIters := 0
+	toolCallSig := func(name, arguments string) string {
+		return name + "|" + arguments
+	}
 
 	// 构建初始消息
 	messages := a.buildMessages(userInput)
@@ -136,6 +142,18 @@ func (a *Agent) RunLoopWithSession(ctx context.Context, sess *session.Session, u
 	callOpts := provider.CallOptions{
 		Tools:      fcMgr.BuildTools(),
 		ToolChoice: "auto",
+	}
+	// 若用户显式在输入中点名工具（如“必须调用 file_read”），优先只暴露这些工具，提升可控性。
+	if required := a.extractRequiredToolNames(userInput); len(required) > 0 {
+		filtered := make([]map[string]any, 0, len(required))
+		for _, name := range required {
+			if t, ok := a.tools.Get(name); ok && t.Enabled {
+				filtered = append(filtered, t.ToOpenAIFormat())
+			}
+		}
+		if len(filtered) > 0 {
+			callOpts.Tools = filtered
+		}
 	}
 
 	for i := 0; i < loopCfg.MaxIterations; i++ {
@@ -164,6 +182,43 @@ func (a *Agent) RunLoopWithSession(ctx context.Context, sess *session.Session, u
 		// 检查是否有工具调用
 		if len(resp.ToolCalls) > 0 {
 			result.State = StateAct
+			if strings.TrimSpace(resp.Content) == "" {
+				consecutiveToolOnlyIters++
+			} else {
+				consecutiveToolOnlyIters = 0
+			}
+
+			// 防止模型陷入重复工具调用死循环（尤其是 skill_read 反复触发）。
+			repeatedSigs := make([]string, 0, len(resp.ToolCalls))
+			allRepeated := true
+			for _, tc := range resp.ToolCalls {
+				sig := toolCallSig(tc.Name, tc.Arguments)
+				repeatedSigs = append(repeatedSigs, sig)
+				toolCallRepeatCount[sig]++
+				if toolCallRepeatCount[sig] < 3 {
+					allRepeated = false
+				}
+			}
+			if (allRepeated && strings.TrimSpace(resp.Content) == "") || consecutiveToolOnlyIters >= 3 {
+				var b strings.Builder
+				b.WriteString("Detected repeated tool-call loop and stopped early to avoid timeout.\n")
+				b.WriteString("Latest tool outputs:\n")
+				for _, sig := range repeatedSigs {
+					parts := strings.SplitN(sig, "|", 2)
+					name := parts[0]
+					out := strings.TrimSpace(toolCallLastResult[sig])
+					if out == "" {
+						out = "(no cached output)"
+					}
+					if len(out) > 240 {
+						out = out[:240] + "...(truncated)"
+					}
+					b.WriteString(fmt.Sprintf("- %s: %s\n", name, out))
+				}
+				result.Response = b.String()
+				result.State = StateDone
+				return result, nil
+			}
 
 			// 将 assistant 消息（含 tool_calls）加入历史
 			messages = append(messages, provider.Message{
@@ -282,6 +337,7 @@ func (a *Agent) RunLoopWithSession(ctx context.Context, sess *session.Session, u
 			for _, r := range allResults {
 				result.ToolCalls = append(result.ToolCalls, r.ToolCall)
 				messages = append(messages, r.ToolMessage)
+				toolCallLastResult[toolCallSig(r.ToolCall.Name, r.ToolCall.Arguments)] = r.ToolCall.Result
 				if sess != nil {
 					sess.AddProviderMessage(r.ToolMessage)
 				}
@@ -339,6 +395,39 @@ func (a *Agent) RunLoopWithSession(ctx context.Context, sess *session.Session, u
 	}
 
 	return result, fmt.Errorf("max iterations (%d) reached", loopCfg.MaxIterations)
+}
+
+// extractRequiredToolNames 从用户输入中提取显式点名的工具（按出现顺序）。
+func (a *Agent) extractRequiredToolNames(input string) []string {
+	type hit struct {
+		name string
+		pos  int
+	}
+
+	var hits []hit
+	for _, t := range a.tools.ListEnabled() {
+		if idx := strings.Index(input, t.Name); idx >= 0 {
+			hits = append(hits, hit{name: t.Name, pos: idx})
+		}
+	}
+	if len(hits) == 0 {
+		return nil
+	}
+
+	sort.SliceStable(hits, func(i, j int) bool {
+		return hits[i].pos < hits[j].pos
+	})
+
+	seen := make(map[string]struct{}, len(hits))
+	result := make([]string, 0, len(hits))
+	for _, h := range hits {
+		if _, ok := seen[h.name]; ok {
+			continue
+		}
+		seen[h.name] = struct{}{}
+		result = append(result, h.name)
+	}
+	return result
 }
 
 // fitContextWindow 裁剪消息列表到上下文窗口内

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -28,8 +28,8 @@ var (
 type LoopState int
 
 const (
-	StateReason LoopState = iota // 推理：分析用户意图，决定下一步
-	StateAct                     // 行动：调用工具或生成回复
+	StateReason  LoopState = iota // 推理：分析用户意图，决定下一步
+	StateAct                      // 行动：调用工具或生成回复
 	StateObserve                  // 观察：处理工具结果，决定是否继续
 	StateDone                     // 完成：输出最终结果
 )
@@ -86,11 +86,11 @@ func sanitizeLoopConfig(cfg *LoopConfig) {
 
 // LoopResult 是 Agent Loop 的执行结果
 type LoopResult struct {
-	Response    string        // 最终回复
-	Iterations  int           // 实际循环次数
-	ToolCalls   []toolCallLog // 工具调用记录
-	State       LoopState     // 结束状态
-	TokensUsed  int           // 总 token 消耗
+	Response   string        // 最终回复
+	Iterations int           // 实际循环次数
+	ToolCalls  []toolCallLog // 工具调用记录
+	State      LoopState     // 结束状态
+	TokensUsed int           // 总 token 消耗
 }
 
 type toolCallLog struct {
@@ -174,7 +174,11 @@ func (a *Agent) RunLoopWithSession(ctx context.Context, sess *session.Session, u
 
 			// 写入 session：assistant 的 tool_calls
 			if sess != nil {
-				sess.AddMessage("assistant", resp.Content)
+				sess.AddProviderMessage(provider.Message{
+					Role:      "assistant",
+					Content:   resp.Content,
+					ToolCalls: resp.ToolCalls,
+				})
 			}
 
 			// Act: 执行工具调用（并发优化：无依赖的工具并行执行）
@@ -186,8 +190,8 @@ func (a *Agent) RunLoopWithSession(ctx context.Context, sess *session.Session, u
 
 			// 分析依赖：shell/file_write/remember 等有状态工具必须串行
 			// 无状态工具（web_search, web_fetch, file_read, current_time, recall）可并发
-			var parallelGroup []int  // 可并发的工具索引
-			var serialGroup []int    // 必须串行的工具索引
+			var parallelGroup []int // 可并发的工具索引
+			var serialGroup []int   // 必须串行的工具索引
 
 			for i, tc := range resp.ToolCalls {
 				if a.isToolParallelSafe(tc.Name) {
@@ -279,23 +283,23 @@ func (a *Agent) RunLoopWithSession(ctx context.Context, sess *session.Session, u
 				result.ToolCalls = append(result.ToolCalls, r.ToolCall)
 				messages = append(messages, r.ToolMessage)
 				if sess != nil {
-					sess.AddToolMessage(r.ToolMessage.Name, r.ToolMessage.Content)
+					sess.AddProviderMessage(r.ToolMessage)
 				}
 			}
 
-	// 每轮工具调用后裁剪上下文窗口
-	messages = a.fitContextWindow(messages)
+			// 每轮工具调用后裁剪上下文窗口
+			messages = a.fitContextWindow(messages)
 
-	result.State = StateObserve
-	
-	// v0.24.1: 工具调用后保存会话
-	if sess != nil {
-		if saveErr := sess.Save(); saveErr != nil {
-			fmt.Printf("[agent] warning: failed to save session: %v\n", saveErr)
-		}
-	}
-	
-	continue // 继续循环，让 LLM 处理工具结果
+			result.State = StateObserve
+
+			// v0.24.1: 工具调用后保存会话
+			if sess != nil {
+				if saveErr := sess.Save(); saveErr != nil {
+					fmt.Printf("[agent] warning: failed to save session: %v\n", saveErr)
+				}
+			}
+
+			continue // 继续循环，让 LLM 处理工具结果
 		}
 
 		// 没有工具调用，LLM 直接给出最终回复
@@ -326,14 +330,14 @@ func (a *Agent) RunLoopWithSession(ctx context.Context, sess *session.Session, u
 	// 达到最大循环次数
 	result.Response = "Max iterations reached, last response may be incomplete"
 	result.State = StateDone
-	
+
 	// v0.24.1: 保存会话到磁盘
 	if sess != nil {
 		if saveErr := sess.Save(); saveErr != nil {
 			fmt.Printf("[agent] warning: failed to save session: %v\n", saveErr)
 		}
 	}
-	
+
 	return result, fmt.Errorf("max iterations (%d) reached", loopCfg.MaxIterations)
 }
 
@@ -435,10 +439,10 @@ type EventType int
 const (
 	EventReason  EventType = iota // 推理阶段
 	EventAct                      // 行动阶段
-	EventObserve                   // 观察阶段
-	EventContent                   // 内容片段
-	EventDone                      // 完成
-	EventError                     // 错误
+	EventObserve                  // 观察阶段
+	EventContent                  // 内容片段
+	EventDone                     // 完成
+	EventError                    // 错误
 )
 
 // executeTool 执行工具调用（通过 Gateway）
@@ -677,7 +681,7 @@ func (a *Agent) ParallelSummarize(messages []provider.Message) ([]provider.Messa
 
 	// 并发摘要两半对话
 	ctx := context.Background()
-	
+
 	// 第一部分
 	go func() {
 		prompt := summarizePrompt(firstHalf, "(first part)")
@@ -685,7 +689,7 @@ func (a *Agent) ParallelSummarize(messages []provider.Message) ([]provider.Messa
 			{Role: "system", Content: "You are a helpful assistant that summarizes conversations."},
 			{Role: "user", Content: prompt},
 		}
-		
+
 		resp, err := a.provider.Chat(ctx, messages)
 		if err != nil {
 			resultCh <- summarizeResult{summary: "", err: err}
@@ -701,7 +705,7 @@ func (a *Agent) ParallelSummarize(messages []provider.Message) ([]provider.Messa
 			{Role: "system", Content: "You are a helpful assistant that summarizes conversations."},
 			{Role: "user", Content: prompt},
 		}
-		
+
 		resp, err := a.provider.Chat(ctx, messages)
 		if err != nil {
 			resultCh <- summarizeResult{summary: "", err: err}
@@ -734,16 +738,16 @@ func (a *Agent) ParallelSummarize(messages []provider.Message) ([]provider.Messa
 
 	// 构建新的消息列表：system + 摘要 + 最近少量原始消息
 	newMessages := make([]provider.Message, 0, len(systemMsgs)+1+5)
-	
+
 	// 添加 system 消息
 	newMessages = append(newMessages, systemMsgs...)
-	
+
 	// 添加摘要消息
 	newMessages = append(newMessages, provider.Message{
 		Role:    "system",
 		Content: summaryContent.String(),
 	})
-	
+
 	// 保留最后 5 条原始对话作为上下文
 	keepCount := 5
 	if keepCount > len(conversationMsgs) {

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"testing"
+
+	"github.com/yurika0211/luckyharness/internal/tool"
 )
 
 func TestLoopStateString(t *testing.T) {
@@ -28,5 +30,22 @@ func TestDefaultLoopConfig(t *testing.T) {
 	}
 	if cfg.AutoApprove != false {
 		t.Error("expected AutoApprove false by default")
+	}
+}
+
+func TestExtractRequiredToolNames(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Register(&tool.Tool{Name: "file_read", Enabled: true})
+	reg.Register(&tool.Tool{Name: "current_time", Enabled: true})
+	reg.Register(&tool.Tool{Name: "shell", Enabled: true})
+
+	a := &Agent{tools: reg}
+	got := a.extractRequiredToolNames("请必须调用 file_read 和 current_time，最后不要用 shell")
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 required tools, got %d (%v)", len(got), got)
+	}
+	if got[0] != "file_read" || got[1] != "current_time" || got[2] != "shell" {
+		t.Fatalf("unexpected order: %v", got)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,20 +5,22 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 )
 
 // Config 代表 LuckyHarness 的运行时配置
 type Config struct {
-	Provider    string            `json:"provider"`
-	APIKey      string            `json:"api_key"`
-	APIBase     string            `json:"api_base,omitempty"`
-	Model       string            `json:"model"`
-	SoulPath    string            `json:"soul_path,omitempty"`
-	MaxTokens   int               `json:"max_tokens"`
-	Temperature float64           `json:"temperature"`
-	Extra       map[string]string `json:"extra,omitempty"`
+	Provider     string            `json:"provider"`
+	APIKey       string            `json:"api_key"`
+	APIBase      string            `json:"api_base,omitempty"`
+	Model        string            `json:"model"`
+	SoulPath     string            `json:"soul_path,omitempty"`
+	MaxTokens    int               `json:"max_tokens"`
+	Temperature  float64           `json:"temperature"`
+	Extra        map[string]string `json:"extra,omitempty"`
+	ExtraHeaders map[string]string `json:"extra_headers,omitempty"`
 
 	// v0.3.0: 降级链配置
 	Fallbacks []FallbackEntry `json:"fallbacks,omitempty"`
@@ -32,85 +34,147 @@ type Config struct {
 	// v0.43.0: 记忆系统配置
 	Memory MemoryConfig `json:"memory,omitempty"`
 
-// v0.45.0: 模型路由配置
-ModelRouter ModelRouterConfig `json:"model_router,omitempty"`
+	// v0.45.0: 模型路由配置
+	ModelRouter ModelRouterConfig `json:"model_router,omitempty"`
 
-// v0.56.0: 限制配置
-Limits LimitsConfig `json:"limits,omitempty"`
+	// v0.56.0: 限制配置
+	Limits LimitsConfig `json:"limits,omitempty"`
 
-// v0.56.0: 重试配置
-Retry RetryConfig `json:"retry,omitempty"`
+	// v0.56.0: 重试配置
+	Retry RetryConfig `json:"retry,omitempty"`
 
-// v0.56.0: 熔断器配置
-CircuitBreaker CircuitBreakerConfig `json:"circuit_breaker,omitempty"`
+	// v0.56.0: 熔断器配置
+	CircuitBreaker CircuitBreakerConfig `json:"circuit_breaker,omitempty"`
 
-// v0.56.0: 限流配置
-RateLimit RateLimitConfig `json:"rate_limit,omitempty"`
+	// v0.56.0: 限流配置
+	RateLimit RateLimitConfig `json:"rate_limit,omitempty"`
 
-// v0.56.0: 上下文配置
-Context ContextConfig `json:"context,omitempty"`
+	// v0.56.0: 上下文配置
+	Context ContextConfig `json:"context,omitempty"`
+
+	// v0.64.0: Agent Loop 配置
+	Agent AgentLoopConfig `json:"agent,omitempty"`
+
+	// v0.64.0: API Server 配置
+	Server ServerConfig `json:"server,omitempty"`
+
+	// v0.64.0: Dashboard 配置
+	Dashboard DashboardConfig `json:"dashboard,omitempty"`
+
+	// v0.64.0: Messaging Gateway 配置
+	MsgGateway MsgGatewayConfig `json:"msg_gateway,omitempty"`
 }
 
 // LimitsConfig 限制配置
 type LimitsConfig struct {
-MaxTokens              int     `json:"max_tokens"`
-Temperature            float64 `json:"temperature"`
-TimeoutSeconds         int     `json:"timeout_seconds"`
-MaxTimeoutSeconds      int     `json:"max_timeout_seconds"`
-MaxToolCalls           int     `json:"max_tool_calls"`
-MaxConcurrentToolCalls int     `json:"max_concurrent_tool_calls"`
+	MaxTokens              int     `json:"max_tokens"`
+	Temperature            float64 `json:"temperature"`
+	TimeoutSeconds         int     `json:"timeout_seconds"`
+	MaxTimeoutSeconds      int     `json:"max_timeout_seconds"`
+	MaxToolCalls           int     `json:"max_tool_calls"`
+	MaxConcurrentToolCalls int     `json:"max_concurrent_tool_calls"`
 }
 
 // RetryConfig 重试配置
 type RetryConfig struct {
-Enabled            bool `json:"enabled"`
-MaxAttempts        int  `json:"max_attempts"`
-InitialDelayMs     int  `json:"initial_delay_ms"`
-MaxDelayMs         int  `json:"max_delay_ms"`
-RetryOnRateLimit   bool `json:"retry_on_rate_limit"`
-RetryOnTimeout     bool `json:"retry_on_timeout"`
-RetryOnServerError bool `json:"retry_on_server_error"`
+	Enabled            bool `json:"enabled"`
+	MaxAttempts        int  `json:"max_attempts"`
+	InitialDelayMs     int  `json:"initial_delay_ms"`
+	MaxDelayMs         int  `json:"max_delay_ms"`
+	RetryOnRateLimit   bool `json:"retry_on_rate_limit"`
+	RetryOnTimeout     bool `json:"retry_on_timeout"`
+	RetryOnServerError bool `json:"retry_on_server_error"`
 }
 
 // CircuitBreakerConfig 熔断器配置
 type CircuitBreakerConfig struct {
-Enabled         bool `json:"enabled"`
-ErrorThreshold  int  `json:"error_threshold"`
-WindowSeconds   int  `json:"window_seconds"`
-TimeoutSeconds  int  `json:"timeout_seconds"`
-HalfOpenMaxReqs int  `json:"half_open_max_requests"`
+	Enabled         bool `json:"enabled"`
+	ErrorThreshold  int  `json:"error_threshold"`
+	WindowSeconds   int  `json:"window_seconds"`
+	TimeoutSeconds  int  `json:"timeout_seconds"`
+	HalfOpenMaxReqs int  `json:"half_open_max_requests"`
 }
 
 // RateLimitConfig 限流配置
 type RateLimitConfig struct {
-Enabled           bool `json:"enabled"`
-RequestsPerMinute int  `json:"requests_per_minute"`
-TokensPerMinute   int  `json:"tokens_per_minute"`
-BurstSize         int  `json:"burst_size"`
+	Enabled           bool `json:"enabled"`
+	RequestsPerMinute int  `json:"requests_per_minute"`
+	TokensPerMinute   int  `json:"tokens_per_minute"`
+	BurstSize         int  `json:"burst_size"`
 }
 
 // ContextConfig 上下文配置
 type ContextConfig struct {
-MaxHistoryTurns      int     `json:"max_history_turns"`
-MaxContextTokens     int     `json:"max_context_tokens"`
-CompressionThreshold float64 `json:"compression_threshold"`
+	MaxHistoryTurns      int     `json:"max_history_turns"`
+	MaxContextTokens     int     `json:"max_context_tokens"`
+	CompressionThreshold float64 `json:"compression_threshold"`
+}
+
+// AgentLoopConfig Agent Loop 配置
+type AgentLoopConfig struct {
+	MaxIterations  int  `json:"max_iterations,omitempty"`
+	TimeoutSeconds int  `json:"timeout_seconds,omitempty"`
+	AutoApprove    bool `json:"auto_approve,omitempty"`
+}
+
+// ServerConfig API Server 配置
+type ServerConfig struct {
+	Addr        string   `json:"addr,omitempty"`
+	APIKeys     []string `json:"api_keys,omitempty"`
+	EnableCORS  bool     `json:"enable_cors,omitempty"`
+	CORSOrigins []string `json:"cors_origins,omitempty"`
+	RateLimit   int      `json:"rate_limit,omitempty"`
+	MetricsAddr string   `json:"metrics_addr,omitempty"`
+	LogLevel    string   `json:"log_level,omitempty"`
+	LogFormat   string   `json:"log_format,omitempty"`
+}
+
+// DashboardConfig Dashboard 配置
+type DashboardConfig struct {
+	Addr string `json:"addr,omitempty"`
+}
+
+// MsgGatewayConfig 消息网关配置
+type MsgGatewayConfig struct {
+	Platform string             `json:"platform,omitempty"`
+	StartAll bool               `json:"start_all,omitempty"`
+	APIAddr  string             `json:"api_addr,omitempty"`
+	Token    string             `json:"token,omitempty"` // 兼容: telegram token
+	Telegram MsgGatewayTelegram `json:"telegram,omitempty"`
+	OneBot   MsgGatewayOneBot   `json:"onebot,omitempty"`
+}
+
+// MsgGatewayTelegram Telegram 网关配置
+type MsgGatewayTelegram struct {
+	Token string `json:"token,omitempty"`
+}
+
+// MsgGatewayOneBot OneBot 网关配置
+type MsgGatewayOneBot struct {
+	APIBase     string `json:"api_base,omitempty"`
+	WSURL       string `json:"ws_url,omitempty"`
+	AccessToken string `json:"access_token,omitempty"`
+	BotID       string `json:"bot_id,omitempty"`
+	ShowTyping  bool   `json:"show_typing,omitempty"`
+	AutoLike    bool   `json:"auto_like,omitempty"`
+	LikeTimes   int    `json:"like_times,omitempty"`
 }
 
 // MemoryConfig 记忆系统配置
 type MemoryConfig struct {
-	ShortTermMaxTurns  int `json:"short_term_max_turns,omitempty"`  // 短期记忆最大轮数（默认 10）
-	MidTermExpireDays  int `json:"midterm_expire_days,omitempty"`   // 中期记忆过期天数（默认 90）
+	ShortTermMaxTurns   int `json:"short_term_max_turns,omitempty"`  // 短期记忆最大轮数（默认 10）
+	MidTermExpireDays   int `json:"midterm_expire_days,omitempty"`   // 中期记忆过期天数（默认 90）
 	MidTermMaxSummaries int `json:"midterm_max_summaries,omitempty"` // 中期记忆最大摘要数（默认 100）
 }
 
 // ModelRouterConfig 模型路由配置
 type ModelRouterConfig struct {
-	Enable       bool   `json:"enable,omitempty"`        // 是否启用模型路由
-	SimpleModel  string `json:"simple_model,omitempty"`  // 简单任务模型（便宜/快速）
-	ComplexModel string `json:"complex_model,omitempty"` // 复杂任务模型（强/慢）
-	LocalModel   string `json:"local_model,omitempty"`   // 本地模型（ollama）
+	Enable       bool   `json:"enable,omitempty"`         // 是否启用模型路由
+	SimpleModel  string `json:"simple_model,omitempty"`   // 简单任务模型（便宜/快速）
+	ComplexModel string `json:"complex_model,omitempty"`  // 复杂任务模型（强/慢）
+	LocalModel   string `json:"local_model,omitempty"`    // 本地模型（ollama）
 	LocalBaseURL string `json:"local_base_url,omitempty"` // 本地模型 API 地址
-	
+
 	// 自动路由阈值
 	TokenThreshold int `json:"token_threshold,omitempty"` // 超过此 token 数视为复杂任务（默认 500）
 }
@@ -119,9 +183,9 @@ type ModelRouterConfig struct {
 type TaskComplexity int
 
 const (
-	TaskSimple  TaskComplexity = iota // 简单任务：问候、简单问答
-	TaskModerate                      // 中等任务：一般查询、简单分析
-	TaskComplex                       // 复杂任务：代码生成、复杂分析、多步骤推理
+	TaskSimple   TaskComplexity = iota // 简单任务：问候、简单问答
+	TaskModerate                       // 中等任务：一般查询、简单分析
+	TaskComplex                        // 复杂任务：代码生成、复杂分析、多步骤推理
 )
 
 // ModelRouter 模型路由器
@@ -157,27 +221,27 @@ func (r *ModelRouter) SelectModel(complexity TaskComplexity) (model string, apiB
 			return r.config.LocalModel, r.config.LocalBaseURL
 		}
 	}
-	
+
 	return "", ""
 }
 
 // EstimateComplexity 根据输入估算任务复杂度
 func (r *ModelRouter) EstimateComplexity(input string, tokenCount int) TaskComplexity {
 	inputLower := strings.ToLower(input)
-	
+
 	// 简单任务关键词
 	simpleKeywords := []string{
 		"hello", "hi", "hey", "good morning", "good night",
 		"谢谢", "你好", "再见", "早上好", "晚安",
 		"what time", "current time", "date",
 	}
-	
+
 	for _, kw := range simpleKeywords {
 		if strings.Contains(inputLower, kw) {
 			return TaskSimple
 		}
 	}
-	
+
 	// 复杂任务关键词
 	complexKeywords := []string{
 		"write code", "implement", "create a program", "build",
@@ -187,13 +251,13 @@ func (r *ModelRouter) EstimateComplexity(input string, tokenCount int) TaskCompl
 		"分析", "比较", "详细解释", "逐步",
 		"优化", "重构", "调试", "设计",
 	}
-	
+
 	for _, kw := range complexKeywords {
 		if strings.Contains(inputLower, kw) {
 			return TaskComplex
 		}
 	}
-	
+
 	// 根据 token 数判断
 	if tokenCount > r.config.TokenThreshold {
 		if r.config.TokenThreshold <= 0 {
@@ -201,7 +265,7 @@ func (r *ModelRouter) EstimateComplexity(input string, tokenCount int) TaskCompl
 		}
 		return TaskComplex
 	}
-	
+
 	// 默认为中等任务
 	return TaskModerate
 }
@@ -215,14 +279,14 @@ func (r *ModelRouter) IsLocalTask(input string) bool {
 		"文件", "目录", "文件夹", "路径",
 		"运行", "执行", "命令", "终端",
 	}
-	
+
 	inputLower := strings.ToLower(input)
 	for _, kw := range localKeywords {
 		if strings.Contains(inputLower, kw) {
 			return true
 		}
 	}
-	
+
 	return false
 }
 
@@ -231,12 +295,12 @@ func (r *ModelRouter) SelectModelForTask(taskDescription string, tokenCount int)
 	if !r.config.Enable {
 		return "", ""
 	}
-	
+
 	// 如果是本地任务，优先使用本地模型
 	if r.IsLocalTask(taskDescription) && r.config.LocalModel != "" {
 		return r.config.LocalModel, r.config.LocalBaseURL
 	}
-	
+
 	// 估算复杂度
 	complexity := r.EstimateComplexity(taskDescription, tokenCount)
 	return r.SelectModel(complexity)
@@ -244,11 +308,11 @@ func (r *ModelRouter) SelectModelForTask(taskDescription string, tokenCount int)
 
 // WebSearchConfig 网络搜索配置（照 nanobot WebSearchConfig 设计）
 type WebSearchConfig struct {
-	Provider    string `json:"provider,omitempty"`    // brave, ddgs, searxng（默认 brave）
-	APIKey      string `json:"api_key,omitempty"`     // Brave / Tavily / Jina API key
-	BaseURL     string `json:"base_url,omitempty"`    // SearXNG 自部署地址
-	MaxResults  int    `json:"max_results,omitempty"` // 最大结果数（默认 5）
-	Proxy       string `json:"proxy,omitempty"`       // HTTP/SOCKS5 代理
+	Provider   string `json:"provider,omitempty"`    // brave, ddgs, searxng（默认 brave）
+	APIKey     string `json:"api_key,omitempty"`     // Brave / Tavily / Jina API key
+	BaseURL    string `json:"base_url,omitempty"`    // SearXNG 自部署地址
+	MaxResults int    `json:"max_results,omitempty"` // 最大结果数（默认 5）
+	Proxy      string `json:"proxy,omitempty"`       // HTTP/SOCKS5 代理
 }
 
 // FallbackEntry 是降级链中的一个节点配置
@@ -263,26 +327,269 @@ type FallbackEntry struct {
 func DefaultConfig() *Config {
 	home, _ := os.UserHomeDir()
 	return &Config{
-		Provider:    "openai",
-		Model:       "gpt-4o",
-		SoulPath:    filepath.Join(home, ".luckyharness", "SOUL.md"),
-		MaxTokens:   4096,
-		Temperature: 0.7,
-		Extra:       make(map[string]string),
+		Provider:     "openai",
+		Model:        "gpt-4o",
+		SoulPath:     filepath.Join(home, ".luckyharness", "SOUL.md"),
+		MaxTokens:    4096,
+		Temperature:  0.7,
+		Extra:        make(map[string]string),
+		ExtraHeaders: make(map[string]string),
+		WebSearch: WebSearchConfig{
+			Provider:   "brave",
+			MaxResults: 5,
+		},
+		StreamMode: "native",
 		Memory: MemoryConfig{
 			ShortTermMaxTurns:   10,
 			MidTermExpireDays:   365,
 			MidTermMaxSummaries: 100,
 		},
+		Limits: LimitsConfig{
+			MaxTokens:              4096,
+			Temperature:            0.7,
+			TimeoutSeconds:         60,
+			MaxTimeoutSeconds:      600,
+			MaxToolCalls:           5,
+			MaxConcurrentToolCalls: 3,
+		},
+		Retry: RetryConfig{
+			Enabled:            true,
+			MaxAttempts:        3,
+			InitialDelayMs:     1000,
+			MaxDelayMs:         10000,
+			RetryOnRateLimit:   true,
+			RetryOnTimeout:     true,
+			RetryOnServerError: true,
+		},
+		CircuitBreaker: CircuitBreakerConfig{
+			Enabled:         false,
+			ErrorThreshold:  5,
+			WindowSeconds:   60,
+			TimeoutSeconds:  30,
+			HalfOpenMaxReqs: 1,
+		},
+		RateLimit: RateLimitConfig{
+			Enabled:           true,
+			RequestsPerMinute: 60,
+			TokensPerMinute:   100000,
+			BurstSize:         10,
+		},
+		Context: ContextConfig{
+			MaxHistoryTurns:      50,
+			MaxContextTokens:     8000,
+			CompressionThreshold: 0.8,
+		},
+		Agent: AgentLoopConfig{
+			MaxIterations:  10,
+			TimeoutSeconds: 60,
+			AutoApprove:    false,
+		},
+		Server: ServerConfig{
+			Addr:        "127.0.0.1:9090",
+			EnableCORS:  true,
+			CORSOrigins: []string{"*"},
+			RateLimit:   60,
+			LogLevel:    "info",
+			LogFormat:   "text",
+		},
+		Dashboard: DashboardConfig{
+			Addr: ":8765",
+		},
+		MsgGateway: MsgGatewayConfig{
+			APIAddr: "127.0.0.1:9090",
+			OneBot: MsgGatewayOneBot{
+				ShowTyping: true,
+				AutoLike:   true,
+				LikeTimes:  1,
+			},
+		},
 	}
+}
+
+func parseConfigData(data []byte) (*Config, error) {
+	cfg := DefaultConfig()
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return cfg, nil
+	}
+	if err := json.Unmarshal(data, cfg); err != nil {
+		return nil, err
+	}
+	normalizeConfig(cfg)
+	return cfg, nil
+}
+
+func normalizeConfig(cfg *Config) {
+	def := DefaultConfig()
+
+	if cfg.Provider == "" {
+		cfg.Provider = def.Provider
+	}
+	if cfg.Model == "" {
+		cfg.Model = def.Model
+	}
+	if cfg.SoulPath == "" {
+		cfg.SoulPath = def.SoulPath
+	}
+	if cfg.MaxTokens <= 0 {
+		cfg.MaxTokens = def.MaxTokens
+	}
+	if cfg.Extra == nil {
+		cfg.Extra = make(map[string]string)
+	}
+	if cfg.ExtraHeaders == nil {
+		cfg.ExtraHeaders = make(map[string]string)
+	}
+	if cfg.WebSearch.Provider == "" {
+		cfg.WebSearch.Provider = def.WebSearch.Provider
+	}
+	if cfg.WebSearch.MaxResults <= 0 {
+		cfg.WebSearch.MaxResults = def.WebSearch.MaxResults
+	}
+	if cfg.StreamMode == "" {
+		cfg.StreamMode = def.StreamMode
+	}
+	if cfg.Memory.ShortTermMaxTurns <= 0 {
+		cfg.Memory.ShortTermMaxTurns = def.Memory.ShortTermMaxTurns
+	}
+	if cfg.Memory.MidTermExpireDays <= 0 {
+		cfg.Memory.MidTermExpireDays = def.Memory.MidTermExpireDays
+	}
+	if cfg.Memory.MidTermMaxSummaries <= 0 {
+		cfg.Memory.MidTermMaxSummaries = def.Memory.MidTermMaxSummaries
+	}
+	if cfg.ModelRouter.TokenThreshold <= 0 {
+		cfg.ModelRouter.TokenThreshold = 500
+	}
+
+	if cfg.Limits.MaxTokens <= 0 {
+		cfg.Limits.MaxTokens = def.Limits.MaxTokens
+	}
+	if cfg.Limits.TimeoutSeconds <= 0 {
+		cfg.Limits.TimeoutSeconds = def.Limits.TimeoutSeconds
+	}
+	if cfg.Limits.MaxTimeoutSeconds <= 0 {
+		cfg.Limits.MaxTimeoutSeconds = def.Limits.MaxTimeoutSeconds
+	}
+	if cfg.Limits.MaxToolCalls <= 0 {
+		cfg.Limits.MaxToolCalls = def.Limits.MaxToolCalls
+	}
+	if cfg.Limits.MaxConcurrentToolCalls <= 0 {
+		cfg.Limits.MaxConcurrentToolCalls = def.Limits.MaxConcurrentToolCalls
+	}
+
+	if cfg.Retry.MaxAttempts <= 0 {
+		cfg.Retry.MaxAttempts = def.Retry.MaxAttempts
+	}
+	if cfg.Retry.InitialDelayMs <= 0 {
+		cfg.Retry.InitialDelayMs = def.Retry.InitialDelayMs
+	}
+	if cfg.Retry.MaxDelayMs <= 0 {
+		cfg.Retry.MaxDelayMs = def.Retry.MaxDelayMs
+	}
+
+	if cfg.CircuitBreaker.ErrorThreshold <= 0 {
+		cfg.CircuitBreaker.ErrorThreshold = def.CircuitBreaker.ErrorThreshold
+	}
+	if cfg.CircuitBreaker.WindowSeconds <= 0 {
+		cfg.CircuitBreaker.WindowSeconds = def.CircuitBreaker.WindowSeconds
+	}
+	if cfg.CircuitBreaker.TimeoutSeconds <= 0 {
+		cfg.CircuitBreaker.TimeoutSeconds = def.CircuitBreaker.TimeoutSeconds
+	}
+	if cfg.CircuitBreaker.HalfOpenMaxReqs <= 0 {
+		cfg.CircuitBreaker.HalfOpenMaxReqs = def.CircuitBreaker.HalfOpenMaxReqs
+	}
+
+	if cfg.RateLimit.RequestsPerMinute <= 0 {
+		cfg.RateLimit.RequestsPerMinute = def.RateLimit.RequestsPerMinute
+	}
+	if cfg.RateLimit.TokensPerMinute <= 0 {
+		cfg.RateLimit.TokensPerMinute = def.RateLimit.TokensPerMinute
+	}
+	if cfg.RateLimit.BurstSize <= 0 {
+		cfg.RateLimit.BurstSize = def.RateLimit.BurstSize
+	}
+
+	if cfg.Context.MaxHistoryTurns <= 0 {
+		cfg.Context.MaxHistoryTurns = def.Context.MaxHistoryTurns
+	}
+	if cfg.Context.MaxContextTokens <= 0 {
+		cfg.Context.MaxContextTokens = def.Context.MaxContextTokens
+	}
+	if cfg.Context.CompressionThreshold <= 0 {
+		cfg.Context.CompressionThreshold = def.Context.CompressionThreshold
+	}
+
+	if cfg.Agent.MaxIterations <= 0 {
+		cfg.Agent.MaxIterations = def.Agent.MaxIterations
+	}
+	if cfg.Agent.TimeoutSeconds <= 0 {
+		cfg.Agent.TimeoutSeconds = def.Agent.TimeoutSeconds
+	}
+
+	if cfg.Server.Addr == "" {
+		cfg.Server.Addr = def.Server.Addr
+	}
+	if cfg.Server.RateLimit <= 0 {
+		cfg.Server.RateLimit = def.Server.RateLimit
+	}
+	if cfg.Server.LogLevel == "" {
+		cfg.Server.LogLevel = def.Server.LogLevel
+	}
+	if cfg.Server.LogFormat == "" {
+		cfg.Server.LogFormat = def.Server.LogFormat
+	}
+	if len(cfg.Server.CORSOrigins) == 0 {
+		cfg.Server.CORSOrigins = append([]string(nil), def.Server.CORSOrigins...)
+	}
+
+	if cfg.Dashboard.Addr == "" {
+		cfg.Dashboard.Addr = def.Dashboard.Addr
+	}
+
+	if cfg.MsgGateway.APIAddr == "" {
+		cfg.MsgGateway.APIAddr = def.MsgGateway.APIAddr
+	}
+	if cfg.MsgGateway.Telegram.Token == "" && cfg.MsgGateway.Token != "" {
+		cfg.MsgGateway.Telegram.Token = cfg.MsgGateway.Token
+	}
+	if cfg.MsgGateway.Token == "" && cfg.MsgGateway.Telegram.Token != "" {
+		cfg.MsgGateway.Token = cfg.MsgGateway.Telegram.Token
+	}
+	if cfg.MsgGateway.OneBot.LikeTimes <= 0 {
+		cfg.MsgGateway.OneBot.LikeTimes = def.MsgGateway.OneBot.LikeTimes
+	}
+}
+
+func cloneConfig(in *Config) *Config {
+	if in == nil {
+		return nil
+	}
+	cp := *in
+	if in.Extra != nil {
+		cp.Extra = make(map[string]string, len(in.Extra))
+		for k, v := range in.Extra {
+			cp.Extra[k] = v
+		}
+	}
+	if in.ExtraHeaders != nil {
+		cp.ExtraHeaders = make(map[string]string, len(in.ExtraHeaders))
+		for k, v := range in.ExtraHeaders {
+			cp.ExtraHeaders[k] = v
+		}
+	}
+	cp.Fallbacks = append([]FallbackEntry(nil), in.Fallbacks...)
+	cp.Server.APIKeys = append([]string(nil), in.Server.APIKeys...)
+	cp.Server.CORSOrigins = append([]string(nil), in.Server.CORSOrigins...)
+	return &cp
 }
 
 // Manager 管理配置的加载和保存
 type Manager struct {
-	mu       sync.RWMutex
-	config   *Config
-	homeDir  string
-	cfgPath  string
+	mu      sync.RWMutex
+	config  *Config
+	homeDir string
+	cfgPath string
 }
 
 // NewManager 创建配置管理器
@@ -322,26 +629,29 @@ func (m *Manager) Load() error {
 		return fmt.Errorf("read config: %w", err)
 	}
 
-	var cfg Config
-	if err := json.Unmarshal(data, &cfg); err != nil {
+	cfg, err := parseConfigData(data)
+	if err != nil {
 		return fmt.Errorf("parse config: %w", err)
 	}
 
-	m.config = &cfg
+	m.config = cfg
 	return nil
 }
 
 // Save 保存配置到磁盘
 func (m *Manager) Save() error {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	if err := os.MkdirAll(m.homeDir, 0700); err != nil {
 		return fmt.Errorf("create config dir: %w", err)
 	}
 
+	normalizeConfig(m.config)
+	out := cloneConfig(m.config)
+
 	// v0.55.1: 使用 JSON 格式保存
-	data, err := json.MarshalIndent(m.config, "", "  ")
+	data, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal config: %w", err)
 	}
@@ -357,8 +667,7 @@ func (m *Manager) Save() error {
 func (m *Manager) Get() *Config {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	cp := *m.config
-	return &cp
+	return cloneConfig(m.config)
 }
 
 // Set 修改配置项
@@ -400,13 +709,194 @@ func (m *Manager) Set(key, value string) error {
 		m.config.WebSearch.Proxy = value
 	case "stream_mode":
 		m.config.StreamMode = value
+	case "agent.max_iterations":
+		var n int
+		fmt.Sscanf(value, "%d", &n)
+		m.config.Agent.MaxIterations = n
+	case "agent.timeout_seconds":
+		var n int
+		fmt.Sscanf(value, "%d", &n)
+		m.config.Agent.TimeoutSeconds = n
+	case "agent.auto_approve":
+		m.config.Agent.AutoApprove = parseBool(value)
+	case "server.addr":
+		m.config.Server.Addr = value
+	case "server.api_keys":
+		m.config.Server.APIKeys = splitCSV(value)
+	case "server.enable_cors":
+		m.config.Server.EnableCORS = parseBool(value)
+	case "server.cors_origins":
+		m.config.Server.CORSOrigins = splitCSV(value)
+	case "server.rate_limit":
+		var n int
+		fmt.Sscanf(value, "%d", &n)
+		m.config.Server.RateLimit = n
+	case "server.metrics_addr":
+		m.config.Server.MetricsAddr = value
+	case "server.log_level":
+		m.config.Server.LogLevel = value
+	case "server.log_format":
+		m.config.Server.LogFormat = value
+	case "dashboard.addr":
+		m.config.Dashboard.Addr = value
+	case "msg_gateway.platform":
+		m.config.MsgGateway.Platform = value
+	case "msg_gateway.start_all":
+		m.config.MsgGateway.StartAll = parseBool(value)
+	case "msg_gateway.api_addr":
+		m.config.MsgGateway.APIAddr = value
+	case "msg_gateway.token":
+		m.config.MsgGateway.Token = value
+		m.config.MsgGateway.Telegram.Token = value
+	case "msg_gateway.telegram.token":
+		m.config.MsgGateway.Telegram.Token = value
+		m.config.MsgGateway.Token = value
+	case "msg_gateway.onebot.api_base":
+		m.config.MsgGateway.OneBot.APIBase = value
+	case "msg_gateway.onebot.ws_url":
+		m.config.MsgGateway.OneBot.WSURL = value
+	case "msg_gateway.onebot.access_token":
+		m.config.MsgGateway.OneBot.AccessToken = value
+	case "msg_gateway.onebot.bot_id":
+		m.config.MsgGateway.OneBot.BotID = value
+	case "msg_gateway.onebot.show_typing":
+		m.config.MsgGateway.OneBot.ShowTyping = parseBool(value)
+	case "msg_gateway.onebot.auto_like":
+		m.config.MsgGateway.OneBot.AutoLike = parseBool(value)
+	case "msg_gateway.onebot.like_times":
+		var n int
+		fmt.Sscanf(value, "%d", &n)
+		m.config.MsgGateway.OneBot.LikeTimes = n
+	case "limits.max_tokens":
+		var n int
+		fmt.Sscanf(value, "%d", &n)
+		m.config.Limits.MaxTokens = n
+	case "limits.temperature":
+		var f float64
+		fmt.Sscanf(value, "%f", &f)
+		m.config.Limits.Temperature = f
+	case "limits.timeout_seconds":
+		var n int
+		fmt.Sscanf(value, "%d", &n)
+		m.config.Limits.TimeoutSeconds = n
+	case "limits.max_timeout_seconds":
+		var n int
+		fmt.Sscanf(value, "%d", &n)
+		m.config.Limits.MaxTimeoutSeconds = n
+	case "limits.max_tool_calls":
+		var n int
+		fmt.Sscanf(value, "%d", &n)
+		m.config.Limits.MaxToolCalls = n
+	case "limits.max_concurrent_tool_calls":
+		var n int
+		fmt.Sscanf(value, "%d", &n)
+		m.config.Limits.MaxConcurrentToolCalls = n
+	case "retry.enabled":
+		m.config.Retry.Enabled = parseBool(value)
+	case "retry.max_attempts":
+		var n int
+		fmt.Sscanf(value, "%d", &n)
+		m.config.Retry.MaxAttempts = n
+	case "retry.initial_delay_ms":
+		var n int
+		fmt.Sscanf(value, "%d", &n)
+		m.config.Retry.InitialDelayMs = n
+	case "retry.max_delay_ms":
+		var n int
+		fmt.Sscanf(value, "%d", &n)
+		m.config.Retry.MaxDelayMs = n
+	case "retry.retry_on_rate_limit":
+		m.config.Retry.RetryOnRateLimit = parseBool(value)
+	case "retry.retry_on_timeout":
+		m.config.Retry.RetryOnTimeout = parseBool(value)
+	case "retry.retry_on_server_error":
+		m.config.Retry.RetryOnServerError = parseBool(value)
+	case "circuit_breaker.enabled":
+		m.config.CircuitBreaker.Enabled = parseBool(value)
+	case "circuit_breaker.error_threshold":
+		var n int
+		fmt.Sscanf(value, "%d", &n)
+		m.config.CircuitBreaker.ErrorThreshold = n
+	case "circuit_breaker.window_seconds":
+		var n int
+		fmt.Sscanf(value, "%d", &n)
+		m.config.CircuitBreaker.WindowSeconds = n
+	case "circuit_breaker.timeout_seconds":
+		var n int
+		fmt.Sscanf(value, "%d", &n)
+		m.config.CircuitBreaker.TimeoutSeconds = n
+	case "circuit_breaker.half_open_max_requests":
+		var n int
+		fmt.Sscanf(value, "%d", &n)
+		m.config.CircuitBreaker.HalfOpenMaxReqs = n
+	case "rate_limit.enabled":
+		m.config.RateLimit.Enabled = parseBool(value)
+	case "rate_limit.requests_per_minute":
+		var n int
+		fmt.Sscanf(value, "%d", &n)
+		m.config.RateLimit.RequestsPerMinute = n
+	case "rate_limit.tokens_per_minute":
+		var n int
+		fmt.Sscanf(value, "%d", &n)
+		m.config.RateLimit.TokensPerMinute = n
+	case "rate_limit.burst_size":
+		var n int
+		fmt.Sscanf(value, "%d", &n)
+		m.config.RateLimit.BurstSize = n
+	case "context.max_history_turns":
+		var n int
+		fmt.Sscanf(value, "%d", &n)
+		m.config.Context.MaxHistoryTurns = n
+	case "context.max_context_tokens":
+		var n int
+		fmt.Sscanf(value, "%d", &n)
+		m.config.Context.MaxContextTokens = n
+	case "context.compression_threshold":
+		var f float64
+		fmt.Sscanf(value, "%f", &f)
+		m.config.Context.CompressionThreshold = f
 	default:
+		if strings.HasPrefix(key, "extra_headers.") {
+			headerKey := strings.TrimPrefix(key, "extra_headers.")
+			if m.config.ExtraHeaders == nil {
+				m.config.ExtraHeaders = make(map[string]string)
+			}
+			if headerKey != "" {
+				m.config.ExtraHeaders[headerKey] = value
+				break
+			}
+		}
 		if m.config.Extra == nil {
 			m.config.Extra = make(map[string]string)
 		}
 		m.config.Extra[key] = value
 	}
 	return nil
+}
+
+func parseBool(s string) bool {
+	v, err := strconv.ParseBool(strings.TrimSpace(strings.ToLower(s)))
+	if err == nil {
+		return v
+	}
+	switch strings.TrimSpace(strings.ToLower(s)) {
+	case "1", "yes", "y", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		item := strings.TrimSpace(p)
+		if item != "" {
+			out = append(out, item)
+		}
+	}
+	return out
 }
 
 // HomeDir 返回 LuckyHarness 主目录

--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -3,11 +3,8 @@ package config
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"sync"
 	"time"
-
-	"gopkg.in/yaml.v3"
 )
 
 // ConfigWatcher 监控配置文件变化并自动重载
@@ -18,8 +15,8 @@ type ConfigWatcher struct {
 	homeDir  string
 	interval time.Duration
 	stopCh   chan struct{}
-	onChange  func(oldCfg, newCfg *Config)
-	onError   func(err error)
+	onChange func(oldCfg, newCfg *Config)
+	onError  func(err error)
 	running  bool
 	lastMod  time.Time
 }
@@ -136,8 +133,8 @@ func (w *ConfigWatcher) checkAndReload() {
 		return
 	}
 
-	var newCfg Config
-	if err := yaml.Unmarshal(data, &newCfg); err != nil {
+	newCfg, err := parseConfigData(data)
+	if err != nil {
 		w.emitError(fmt.Errorf("parse config: %w", err))
 		return
 	}
@@ -150,13 +147,13 @@ func (w *ConfigWatcher) checkAndReload() {
 
 	// 更新配置
 	w.mu.Lock()
-	w.config = &newCfg
+	w.config = newCfg
 	w.lastMod = info.ModTime()
 	w.mu.Unlock()
 
 	// 触发回调
 	if onChange != nil {
-		onChange(&oldCfg, &newCfg)
+		onChange(&oldCfg, newCfg)
 	}
 }
 
@@ -180,14 +177,14 @@ func (w *ConfigWatcher) ForceReload() error {
 		return fmt.Errorf("read config: %w", err)
 	}
 
-	var newCfg Config
-	if err := yaml.Unmarshal(data, &newCfg); err != nil {
+	newCfg, err := parseConfigData(data)
+	if err != nil {
 		return fmt.Errorf("parse config: %w", err)
 	}
 
 	w.mu.Lock()
 	oldCfg := *w.config
-	w.config = &newCfg
+	w.config = newCfg
 	onChange := w.onChange
 	if info, err := os.Stat(w.cfgPath); err == nil {
 		w.lastMod = info.ModTime()
@@ -195,7 +192,7 @@ func (w *ConfigWatcher) ForceReload() error {
 	w.mu.Unlock()
 
 	if onChange != nil {
-		onChange(&oldCfg, &newCfg)
+		onChange(&oldCfg, newCfg)
 	}
 
 	return nil
@@ -288,6 +285,3 @@ func (m *Manager) ConfigFile() string {
 func (m *Manager) HomeDirPath() string {
 	return m.homeDir
 }
-
-// Ensure filepath import is used
-var _ = filepath.Base

--- a/internal/gateway/telegram/handler.go
+++ b/internal/gateway/telegram/handler.go
@@ -3,6 +3,7 @@ package telegram
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -120,12 +121,20 @@ type Handler struct {
 	adapter *Adapter
 	agent   agentProvider
 
-	mu       sync.RWMutex
-	sessions map[string]string // chatID → sessionID
+	mu         sync.RWMutex
+	sessions   map[string]string // chatID → sessionID
+	tasks      map[string]*chatTask
+	restarting bool
 
 	// v0.44.0: chatID→sessionID 映射持久化
 	dataDir string
 }
+
+type chatTask struct {
+	cancel context.CancelFunc
+}
+
+const defaultChatStreamTimeout = 2 * time.Minute
 
 // chatSessionsData 是持久化的 chatID→sessionID 映射
 type chatSessionsData struct {
@@ -142,6 +151,7 @@ func NewHandler(adapter *Adapter, a *agent.Agent) *Handler {
 		adapter:  adapter,
 		agent:    ap,
 		sessions: make(map[string]string),
+		tasks:    make(map[string]*chatTask),
 		dataDir:  "", // 默认不持久化，需 SetDataDir 启用
 	}
 }
@@ -271,6 +281,72 @@ func (h *Handler) setSessionID(chatID, sessionID string) {
 	h.mu.Unlock()
 }
 
+func (h *Handler) dispatchChatAsync(ctx context.Context, msg *gateway.Message, inputText string) error {
+	msgCopy := *msg
+	go func() {
+		if err := h.handleChat(ctx, &msgCopy, inputText); err != nil {
+			fmt.Printf("[telegram] chat error: %v\n", err)
+		}
+	}()
+	return nil
+}
+
+func (h *Handler) beginChatTask(chatID string, parent context.Context) (context.Context, *chatTask) {
+	h.mu.Lock()
+	if h.tasks == nil {
+		h.tasks = make(map[string]*chatTask)
+	}
+	if old := h.tasks[chatID]; old != nil {
+		old.cancel()
+	}
+	taskCtx, cancel := context.WithCancel(parent)
+	task := &chatTask{cancel: cancel}
+	h.tasks[chatID] = task
+	h.mu.Unlock()
+	return taskCtx, task
+}
+
+func (h *Handler) finishChatTask(chatID string, task *chatTask) {
+	if task == nil {
+		return
+	}
+	h.mu.Lock()
+	if cur, ok := h.tasks[chatID]; ok && cur == task {
+		delete(h.tasks, chatID)
+	}
+	h.mu.Unlock()
+	task.cancel()
+}
+
+func (h *Handler) cancelChatTask(chatID string) bool {
+	h.mu.Lock()
+	if h.tasks == nil {
+		h.mu.Unlock()
+		return false
+	}
+	task, ok := h.tasks[chatID]
+	if ok {
+		delete(h.tasks, chatID)
+	}
+	h.mu.Unlock()
+	if !ok || task == nil {
+		return false
+	}
+	task.cancel()
+	return true
+}
+
+func isTaskCanceledError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "context canceled") || strings.Contains(msg, "context deadline exceeded")
+}
+
 // HandleMessage processes an incoming gateway message.
 func (h *Handler) HandleMessage(ctx context.Context, msg *gateway.Message) error {
 	if msg.IsCommand {
@@ -303,11 +379,11 @@ func (h *Handler) HandleMessage(ctx context.Context, msg *gateway.Message) error
 
 	// Regular text in private chats → forward to Agent
 	if msg.Chat.Type == gateway.ChatPrivate {
-		return h.handleChat(ctx, msg, inputText)
+		return h.dispatchChatAsync(ctx, msg, inputText)
 	}
 
 	// Group chats: only respond if mentioned or replied to (already filtered by adapter)
-	return h.handleChat(ctx, msg, inputText)
+	return h.dispatchChatAsync(ctx, msg, inputText)
 }
 
 // handleCommand dispatches bot commands.
@@ -318,7 +394,7 @@ func (h *Handler) handleCommand(ctx context.Context, msg *gateway.Message) error
 	case "help":
 		return h.handleHelp(ctx, msg)
 	case "chat":
-		return h.handleChat(ctx, msg, msg.Args)
+		return h.dispatchChatAsync(ctx, msg, msg.Args)
 	case "model":
 		return h.handleModel(ctx, msg)
 	case "soul":
@@ -423,6 +499,9 @@ func (h *Handler) handleChat(ctx context.Context, msg *gateway.Message, text str
 		return h.adapter.Send(ctx, msg.Chat.ID, "Please provide a message. Usage: /chat <message>")
 	}
 
+	taskCtx, task := h.beginChatTask(msg.Chat.ID, ctx)
+	defer h.finishChatTask(msg.Chat.ID, task)
+
 	// 收到消息后给用户点赞 👍
 	go h.adapter.ReactToMessage(msg.Chat.ID, msg.ID, "👍")
 
@@ -435,14 +514,14 @@ func (h *Handler) handleChat(ctx context.Context, msg *gateway.Message, text str
 	}
 
 	// 尝试流式输出（Adapter 已实现 StreamGateway）
-	sender, err := h.adapter.SendStream(ctx, msg.Chat.ID, msg.ID)
+	sender, err := h.adapter.SendStream(taskCtx, msg.Chat.ID, msg.ID)
 	if err == nil {
-		return h.handleChatStream(ctx, sender, msg, inputText, sessionID)
+		return h.handleChatStream(taskCtx, sender, msg, inputText, sessionID)
 	}
 	// SendStream 失败，回退到非流式
 
 	// 回退到非流式
-	return h.handleChatSync(ctx, msg, inputText, sessionID)
+	return h.handleChatSync(taskCtx, msg, inputText, sessionID)
 }
 
 // handleChatStream 流式对话处理（Telegram 专用）
@@ -452,16 +531,24 @@ func (h *Handler) handleChatStream(ctx context.Context, sender gateway.StreamSen
 	defer typingCancel()
 	go h.adapter.SendTypingLoop(typingCtx, msg.Chat.ID)
 
+	chatCtx, chatCancel := context.WithTimeout(ctx, defaultChatStreamTimeout)
+	defer chatCancel()
+
 	// 启动流式对话
-	events, err := h.agent.ChatWithSessionStream(ctx, sessionID, text)
+	events, err := h.agent.ChatWithSessionStream(chatCtx, sessionID, text)
 	if err != nil {
 		// session 可能坏了，重试
 		if strings.Contains(err.Error(), "session not found") {
 			h.resetSession(msg.Chat.ID)
 			sessionID = h.getSessionID(msg.Chat.ID)
-			events, err = h.agent.ChatWithSessionStream(ctx, sessionID, text)
+			events, err = h.agent.ChatWithSessionStream(chatCtx, sessionID, text)
 		}
 		if err != nil {
+			if isTaskCanceledError(err) {
+				sender.SetResult("🛑 当前任务已停止")
+				sender.Finish()
+				return nil
+			}
 			sender.SetResult(fmt.Sprintf("❌ Error: %s", truncateString(err.Error(), 200)))
 			sender.Finish()
 			return nil
@@ -470,43 +557,82 @@ func (h *Handler) handleChatStream(ctx context.Context, sender gateway.StreamSen
 
 	var finalContent strings.Builder
 	toolCallCount := 0
+	ended := false
+	sentResult := false
 
-	for evt := range events {
-		switch evt.Type {
-		case agent.ChatEventThinking:
-			// 思考状态作为消息前缀展示，不清空已有内容
-			sender.SetThinking(evt.Content)
+	for !ended {
+		select {
+		case <-chatCtx.Done():
+			sender.SetResult("🛑 当前任务已停止")
+			sender.Finish()
+			sentResult = true
+			ended = true
+		case evt, ok := <-events:
+			if !ok {
+				ended = true
+				break
+			}
+			switch evt.Type {
+			case agent.ChatEventThinking:
+				// 思考状态作为消息前缀展示，不清空已有内容
+				sender.SetThinking(evt.Content)
 
-		case agent.ChatEventToolCall:
-			toolCallCount++
-			// 工具调用作为消息前缀展示
-			sender.SetToolCall(evt.Name, evt.Args)
+			case agent.ChatEventToolCall:
+				toolCallCount++
+				// 工具调用作为消息前缀展示
+				sender.SetToolCall(evt.Name, evt.Args)
 
-		case agent.ChatEventToolResult:
-			// 工具结果展示后切回思考状态
-			sender.SetThinking(fmt.Sprintf("Continuing... (%d tools used)", toolCallCount))
+			case agent.ChatEventToolResult:
+				// 工具结果展示后切回思考状态
+				sender.SetThinking(fmt.Sprintf("Continuing... (%d tools used)", toolCallCount))
 
-		case agent.ChatEventContent:
-			// 内容流式追加
-			finalContent.WriteString(evt.Content)
-			sender.Append(evt.Content)
-
-		case agent.ChatEventDone:
-			if finalContent.Len() == 0 {
+			case agent.ChatEventContent:
+				// 内容流式追加
 				finalContent.WriteString(evt.Content)
-			}
-			// 最终结果替换整个消息
-			sender.SetResult(finalContent.String())
-			sender.Finish()
+				sender.Append(evt.Content)
 
-		case agent.ChatEventError:
-			errMsg := evt.Err.Error()
-			if len(errMsg) > 200 {
-				errMsg = errMsg[:197] + "..."
+			case agent.ChatEventDone:
+				if finalContent.Len() == 0 {
+					finalContent.WriteString(evt.Content)
+				}
+				// 最终结果替换整个消息
+				sender.SetResult(finalContent.String())
+				sender.Finish()
+				sentResult = true
+				ended = true
+
+			case agent.ChatEventError:
+				if isTaskCanceledError(evt.Err) {
+					sender.SetResult("🛑 当前任务已停止")
+					sender.Finish()
+					sentResult = true
+					ended = true
+					break
+				}
+				errMsg := evt.Err.Error()
+				if len(errMsg) > 200 {
+					errMsg = errMsg[:197] + "..."
+				}
+				sender.SetResult(fmt.Sprintf("❌ Error: %s", errMsg))
+				sender.Finish()
+				sentResult = true
+				ended = true
 			}
-			sender.SetResult(fmt.Sprintf("❌ Error: %s", errMsg))
-			sender.Finish()
 		}
+	}
+
+	if !sentResult {
+		switch {
+		case finalContent.Len() > 0:
+			sender.SetResult(finalContent.String())
+		case errors.Is(chatCtx.Err(), context.DeadlineExceeded):
+			sender.SetResult("❌ Error: request timed out while waiting for model response")
+		case errors.Is(chatCtx.Err(), context.Canceled):
+			sender.SetResult("🛑 当前任务已停止")
+		default:
+			sender.SetResult("❌ Error: stream ended unexpectedly, please retry")
+		}
+		sender.Finish()
 	}
 
 	return nil
@@ -536,6 +662,9 @@ func (h *Handler) handleChatSync(ctx context.Context, msg *gateway.Message, text
 			response, err = h.agent.ChatWithSession(ctx, sessionID, text)
 		}
 		if err != nil {
+			if isTaskCanceledError(err) {
+				return h.adapter.Send(context.Background(), msg.Chat.ID, "🛑 当前任务已停止")
+			}
 			errMsg := fmt.Sprintf("❌ Error: %s", err.Error())
 			if len(errMsg) > 200 {
 				errMsg = errMsg[:200] + "..."
@@ -882,51 +1011,53 @@ func (h *Handler) handleHealth(ctx context.Context, msg *gateway.Message) error 
 // handleNew 开启新对话（创建新会话）
 func (h *Handler) handleNew(ctx context.Context, msg *gateway.Message) error {
 	chatID := msg.Chat.ID
-	
+
 	// 创建新会话
 	newSess := h.agent.Sessions().New()
-	
+
 	h.mu.Lock()
 	oldSessionID, hadOld := h.sessions[chatID]
 	h.sessions[chatID] = newSess.ID
 	h.mu.Unlock()
-	
+
 	h.saveChatSessions()
-	
+
 	info := ""
 	if hadOld {
 		info = fmt.Sprintf("旧会话：%s\n", oldSessionID)
 	}
-	
+
 	return h.adapter.Send(ctx, chatID, fmt.Sprintf("✅ New session started.\n%s新会话 ID: `%s`", info, newSess.ID))
 }
 
-// handleStop 停止当前任务（占位实现）
+// handleStop 停止当前任务
 func (h *Handler) handleStop(ctx context.Context, msg *gateway.Message) error {
 	chatID := msg.Chat.ID
-	// TODO: 实现真正的任务取消
-	return h.adapter.Send(ctx, chatID, "ℹ️ Stop command received. Task cancellation not yet implemented.")
+	if !h.cancelChatTask(chatID) {
+		return h.adapter.Send(ctx, chatID, "ℹ️ 当前没有运行中的任务")
+	}
+	return h.adapter.Send(ctx, chatID, "🛑 已停止当前任务")
 }
 
 // handleStatus 查看状态
 func (h *Handler) handleStatus(ctx context.Context, msg *gateway.Message) error {
 	chatID := msg.Chat.ID
 	sessionID := h.getSessionID(chatID)
-	
+
 	var sb strings.Builder
 	sb.WriteString("📊 *LuckyHarness Status*\n\n")
-	
+
 	// 版本
 	sb.WriteString(fmt.Sprintf("• Version: v%s\n", "0.55.0"))
-	
+
 	// 模型
 	cfg := h.agent.Config().Get()
 	sb.WriteString(fmt.Sprintf("• Model: %s\n", cfg.Model))
-	
+
 	// 运行时间
 	uptime := time.Since(h.agent.Metrics().StartTime)
 	sb.WriteString(fmt.Sprintf("• Uptime: %s\n", formatDuration(uptime)))
-	
+
 	// 会话历史
 	sess, ok := h.agent.Sessions().Get(sessionID)
 	msgCount := 0
@@ -934,30 +1065,52 @@ func (h *Handler) handleStatus(ctx context.Context, msg *gateway.Message) error 
 		msgCount = sess.MessageCount()
 	}
 	sb.WriteString(fmt.Sprintf("• Session messages: %d\n", msgCount))
-	
+
 	// 指标
 	m := h.agent.Metrics()
 	snapshot := m.Snapshot()
 	sb.WriteString(fmt.Sprintf("• Total requests: %d\n", snapshot.TotalRequests))
-	
+
 	return h.adapter.Send(ctx, chatID, sb.String())
 }
 
 // handleRestart 重启 bot
 func (h *Handler) handleRestart(ctx context.Context, msg *gateway.Message) error {
 	chatID := msg.Chat.ID
-	
-	// 发送重启消息
-	_ = h.adapter.Send(ctx, chatID, "🔄 Restarting...")
-	
-	// 延迟 1 秒后重启
+
+	h.mu.Lock()
+	if h.restarting {
+		h.mu.Unlock()
+		return h.adapter.Send(ctx, chatID, "ℹ️ Bot 正在重启中，请稍候")
+	}
+	h.restarting = true
+	h.mu.Unlock()
+
+	// 先通知，再执行重连
+	_ = h.adapter.Send(ctx, chatID, "🔄 Restarting bot gateway...")
+
 	go func() {
-		time.Sleep(1 * time.Second)
-		// TODO: 实现重启逻辑（需要访问主进程）
-		// 目前只能提示用户手动重启
-		_ = h.adapter.Send(ctx, chatID, "⚠️ Auto-restart not implemented. Please restart manually.")
+		defer func() {
+			h.mu.Lock()
+			h.restarting = false
+			h.mu.Unlock()
+		}()
+
+		// 停止当前 chat 的任务，避免重启期间残留 goroutine
+		h.cancelChatTask(chatID)
+
+		if err := h.adapter.Stop(); err != nil {
+			fmt.Printf("[telegram] restart stop failed: %v\n", err)
+		}
+		time.Sleep(1200 * time.Millisecond)
+
+		if err := h.adapter.Start(context.Background()); err != nil {
+			fmt.Printf("[telegram] restart start failed: %v\n", err)
+			return
+		}
+		_ = h.adapter.Send(context.Background(), chatID, "✅ Bot 已重连并恢复轮询")
 	}()
-	
+
 	return nil
 }
 
@@ -966,7 +1119,7 @@ func formatDuration(d time.Duration) string {
 	days := int(d.Hours() / 24)
 	hours := int(d.Hours()) % 24
 	mins := int(d.Minutes()) % 60
-	
+
 	if days > 0 {
 		return fmt.Sprintf("%dd %dh %dm", days, hours, mins)
 	}

--- a/internal/gateway/telegram/telegram_v054_test.go
+++ b/internal/gateway/telegram/telegram_v054_test.go
@@ -2632,6 +2632,39 @@ func (m *mockConfigProvider) Get() agentConfigSnapshot {
 	return m.snap
 }
 
+type mockStreamSender struct {
+	content  strings.Builder
+	result   string
+	finished bool
+}
+
+func (m *mockStreamSender) Append(content string) error {
+	m.content.WriteString(content)
+	return nil
+}
+
+func (m *mockStreamSender) SetThinking(label string) error {
+	return nil
+}
+
+func (m *mockStreamSender) SetToolCall(name, args string) error {
+	return nil
+}
+
+func (m *mockStreamSender) SetResult(content string) error {
+	m.result = content
+	return nil
+}
+
+func (m *mockStreamSender) Finish() error {
+	m.finished = true
+	return nil
+}
+
+func (m *mockStreamSender) MessageID() string {
+	return "mock-msg-id"
+}
+
 // newHandlerWithMockAgent creates a Handler with a mock agent for testing.
 func newHandlerWithMockAgent(t *testing.T) (*Handler, *httptest.Server) {
 	t.Helper()
@@ -3525,6 +3558,40 @@ func TestV054HandleChatStreamWithToolCall(t *testing.T) {
 	err := handler.handleChat(ctx, msg, "search for test")
 	if err != nil {
 		t.Errorf("expected no error, got: %v", err)
+	}
+}
+
+func TestV054HandleChatStreamUnexpectedClose(t *testing.T) {
+	handler, server := newHandlerWithMockAgent(t)
+	defer server.Close()
+
+	handler.agent.(*mockAgentProvider).chatStreamFn = func(ctx context.Context, sessionID, userInput string) (<-chan agent.ChatEvent, error) {
+		ch := make(chan agent.ChatEvent, 2)
+		ch <- agent.ChatEvent{Type: agent.ChatEventThinking, Content: "thinking..."}
+		ch <- agent.ChatEvent{Type: agent.ChatEventContent, Content: "partial response"}
+		close(ch)
+		return ch, nil
+	}
+
+	msg := &gateway.Message{
+		ID: "1",
+		Chat: gateway.Chat{
+			ID:   "12345",
+			Type: gateway.ChatPrivate,
+		},
+		Text: "hello",
+	}
+	sender := &mockStreamSender{}
+
+	err := handler.handleChatStream(context.Background(), sender, msg, "hello", handler.getSessionID("12345"))
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !sender.finished {
+		t.Fatal("expected stream sender to be finished when event channel closes unexpectedly")
+	}
+	if sender.result != "partial response" {
+		t.Fatalf("expected fallback result from partial content, got: %q", sender.result)
 	}
 }
 

--- a/internal/provider/openai_stream.go
+++ b/internal/provider/openai_stream.go
@@ -17,13 +17,14 @@ import (
 
 // openaiChatRequest 是发送给 OpenAI API 的请求体
 type openaiChatRequest struct {
-	Model       string          `json:"model"`
-	Messages    []openaiMessage `json:"messages"`
-	MaxTokens   int             `json:"max_tokens,omitempty"`
-	Temperature float64         `json:"temperature,omitempty"`
-	Stream      bool            `json:"stream"`
-	Tools       []openaiTool    `json:"tools,omitempty"`
-	ToolChoice  any             `json:"tool_choice,omitempty"`
+	Model               string          `json:"model"`
+	Messages            []openaiMessage `json:"messages"`
+	MaxTokens           int             `json:"max_tokens,omitempty"`
+	MaxCompletionTokens int             `json:"max_completion_tokens,omitempty"`
+	Temperature         float64         `json:"temperature,omitempty"`
+	Stream              bool            `json:"stream"`
+	Tools               []openaiTool    `json:"tools,omitempty"`
+	ToolChoice          any             `json:"tool_choice,omitempty"`
 }
 
 // openaiMessage 是 OpenAI API 的消息格式
@@ -270,11 +271,12 @@ func doOpenAIRequest(ctx context.Context, cfg Config, body []byte) (*http.Respon
 // 支持文本响应和工具调用解析
 func callOpenAI(ctx context.Context, cfg Config, messages []Message, opts CallOptions) (*Response, error) {
 	reqBody := openaiChatRequest{
-		Model:       cfg.Model,
-		Messages:    toOpenAIMessages(messages),
-		MaxTokens:   cfg.MaxTokens,
-		Temperature: cfg.Temperature,
-		Stream:      false,
+		Model:               cfg.Model,
+		Messages:            toOpenAIMessages(messages),
+		MaxTokens:           cfg.MaxTokens,
+		MaxCompletionTokens: cfg.MaxTokens,
+		Temperature:         cfg.Temperature,
+		Stream:              false,
 	}
 
 	// v0.16.0: 添加 function calling 工具定义
@@ -446,11 +448,12 @@ func retryWithStream(ctx context.Context, cfg Config, messages []Message, opts C
 // 支持文本内容和工具调用的流式解析
 func callOpenAIStream(ctx context.Context, cfg Config, messages []Message, opts CallOptions) (<-chan StreamChunk, error) {
 	reqBody := openaiChatRequest{
-		Model:       cfg.Model,
-		Messages:    toOpenAIMessages(messages),
-		MaxTokens:   cfg.MaxTokens,
-		Temperature: cfg.Temperature,
-		Stream:      true,
+		Model:               cfg.Model,
+		Messages:            toOpenAIMessages(messages),
+		MaxTokens:           cfg.MaxTokens,
+		MaxCompletionTokens: cfg.MaxTokens,
+		Temperature:         cfg.Temperature,
+		Stream:              true,
 	}
 
 	// v0.16.0: 添加 function calling 工具定义

--- a/internal/provider/openai_stream.go
+++ b/internal/provider/openai_stream.go
@@ -14,22 +14,22 @@ import (
 
 // openaiChatRequest 是发送给 OpenAI API 的请求体
 type openaiChatRequest struct {
-	Model       string              `json:"model"`
-	Messages    []openaiMessage     `json:"messages"`
-	MaxTokens   int                 `json:"max_tokens,omitempty"`
-	Temperature float64             `json:"temperature,omitempty"`
-	Stream      bool                `json:"stream"`
-	Tools       []openaiTool        `json:"tools,omitempty"`
-	ToolChoice  any                 `json:"tool_choice,omitempty"`
+	Model       string          `json:"model"`
+	Messages    []openaiMessage `json:"messages"`
+	MaxTokens   int             `json:"max_tokens,omitempty"`
+	Temperature float64         `json:"temperature,omitempty"`
+	Stream      bool            `json:"stream"`
+	Tools       []openaiTool    `json:"tools,omitempty"`
+	ToolChoice  any             `json:"tool_choice,omitempty"`
 }
 
 // openaiMessage 是 OpenAI API 的消息格式
 type openaiMessage struct {
-	Role       string              `json:"role"`
-	Content    string              `json:"content,omitempty"`
+	Role       string               `json:"role"`
+	Content    string               `json:"content,omitempty"`
 	ToolCalls  []openaiToolCallResp `json:"tool_calls,omitempty"`
-	ToolCallID string              `json:"tool_call_id,omitempty"` // v0.16.0: tool 消息的 call ID
-	Name       string              `json:"name,omitempty"`         // v0.16.0: tool 消息的函数名
+	ToolCallID string               `json:"tool_call_id,omitempty"` // v0.16.0: tool 消息的 call ID
+	Name       string               `json:"name,omitempty"`         // v0.16.0: tool 消息的函数名
 }
 
 // openaiToolCallResp 是 OpenAI 响应中的工具调用格式
@@ -57,21 +57,21 @@ type toolFunction struct {
 
 // openaiChatResponse 是 OpenAI API 的响应体
 type openaiChatResponse struct {
-	ID      string          `json:"id"`
-	Choices []openaiChoice  `json:"choices"`
-	Usage   *openaiUsage    `json:"usage,omitempty"`
+	ID      string         `json:"id"`
+	Choices []openaiChoice `json:"choices"`
+	Usage   *openaiUsage   `json:"usage,omitempty"`
 }
 
 type openaiChoice struct {
-	Index        int            `json:"index"`
-	Message      openaiMessage  `json:"message"`
-	Delta        *openaiDelta   `json:"delta,omitempty"`
-	FinishReason string         `json:"finish_reason"`
+	Index        int           `json:"index"`
+	Message      openaiMessage `json:"message"`
+	Delta        *openaiDelta  `json:"delta,omitempty"`
+	FinishReason string        `json:"finish_reason"`
 }
 
 type openaiDelta struct {
-	Role      string     `json:"role,omitempty"`
-	Content   string     `json:"content,omitempty"`
+	Role      string          `json:"role,omitempty"`
+	Content   string          `json:"content,omitempty"`
 	ToolCalls []deltaToolCall `json:"tool_calls,omitempty"`
 }
 
@@ -136,7 +136,7 @@ func callOpenAI(ctx context.Context, cfg Config, messages []Message, opts CallOp
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
-	
+
 	// v0.56.0: 添加额外请求头（如 User-Agent）
 	for k, v := range cfg.ExtraHeaders {
 		req.Header.Set(k, v)
@@ -325,7 +325,7 @@ func callOpenAIStream(ctx context.Context, cfg Config, messages []Message, opts 
 	req = req.WithContext(ctx)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
-	
+
 	// v0.56.0: 添加额外请求头（如 User-Agent）
 	for k, v := range cfg.ExtraHeaders {
 		req.Header.Set(k, v)
@@ -391,9 +391,9 @@ func callOpenAIStream(ctx context.Context, cfg Config, messages []Message, opts 
 				deltas := make([]StreamToolCallDelta, 0, len(choice.Delta.ToolCalls))
 				for _, dtc := range choice.Delta.ToolCalls {
 					deltas = append(deltas, StreamToolCallDelta{
-						Index:    dtc.Index,
-						ID:       dtc.ID,
-						Name:     dtc.Function.Name,
+						Index:     dtc.Index,
+						ID:        dtc.ID,
+						Name:      dtc.Function.Name,
 						Arguments: dtc.Function.Arguments,
 					})
 				}
@@ -423,6 +423,23 @@ func callOpenAIStream(ctx context.Context, cfg Config, messages []Message, opts 
 func toOpenAIMessages(messages []Message) []openaiMessage {
 	result := make([]openaiMessage, 0, len(messages))
 	for _, m := range messages {
+		// 兼容旧会话：tool 消息缺失 tool_call_id 时，不能以 role=tool 发送。
+		// 否则部分 API 网关会返回 400（Invalid input[*].call_id）。
+		if m.Role == "tool" && strings.TrimSpace(m.ToolCallID) == "" {
+			content := strings.TrimSpace(m.Content)
+			if content == "" {
+				continue
+			}
+			if m.Name != "" && !strings.HasPrefix(content, "[Tool:") {
+				content = fmt.Sprintf("[Tool: %s] %s", m.Name, content)
+			}
+			result = append(result, openaiMessage{
+				Role:    "assistant",
+				Content: content,
+			})
+			continue
+		}
+
 		msg := openaiMessage{
 			Role:       m.Role,
 			Content:    m.Content,

--- a/internal/provider/openai_stream.go
+++ b/internal/provider/openai_stream.go
@@ -108,13 +108,13 @@ func newOpenAITransport() http.RoundTripper {
 	base, ok := http.DefaultTransport.(*http.Transport)
 	if !ok {
 		return &http.Transport{
-			ForceAttemptHTTP2: false,
+			ForceAttemptHTTP2: true,
 		}
 	}
 	t := base.Clone()
-	// 某些 OpenAI-compatible 代理在 HTTP/2 长连接下会出现 tls: bad record MAC。
-	// 退回 HTTP/1.1 并在重试时主动断开空闲连接，稳定性更高。
-	t.ForceAttemptHTTP2 = false
+	// 保持 HTTP/2 可用：部分 OpenAI-compatible 网关在强制 HTTP/1.1 时会直接返回 HTTP/2 帧，
+	// 触发 malformed HTTP response。连接稳定性问题由 doOpenAIRequest 的重试与断开空闲连接兜底。
+	t.ForceAttemptHTTP2 = true
 	if t.MaxIdleConnsPerHost < 8 {
 		t.MaxIdleConnsPerHost = 8
 	}

--- a/internal/provider/openai_stream.go
+++ b/internal/provider/openai_stream.go
@@ -5,11 +5,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // openaiChatRequest 是发送给 OpenAI API 的请求体
@@ -96,6 +99,173 @@ type openaiSSEEvent struct {
 	Data string
 }
 
+// openAIHTTPClient 使用独立 transport，避免 http.DefaultTransport 在某些代理链路上复用连接导致 TLS 记录损坏。
+var openAIHTTPClient = &http.Client{
+	Transport: newOpenAITransport(),
+}
+
+func newOpenAITransport() http.RoundTripper {
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return &http.Transport{
+			ForceAttemptHTTP2: false,
+		}
+	}
+	t := base.Clone()
+	// 某些 OpenAI-compatible 代理在 HTTP/2 长连接下会出现 tls: bad record MAC。
+	// 退回 HTTP/1.1 并在重试时主动断开空闲连接，稳定性更高。
+	t.ForceAttemptHTTP2 = false
+	if t.MaxIdleConnsPerHost < 8 {
+		t.MaxIdleConnsPerHost = 8
+	}
+	return t
+}
+
+type openAIRetrySettings struct {
+	MaxAttempts  int
+	InitialDelay time.Duration
+	MaxDelay     time.Duration
+}
+
+func resolveOpenAIRetrySettings(cfg Config) openAIRetrySettings {
+	// 默认对传输层抖动做轻量兜底重试；如果显式启用 retry，则使用配置覆盖。
+	out := openAIRetrySettings{
+		MaxAttempts:  2,
+		InitialDelay: 300 * time.Millisecond,
+		MaxDelay:     2 * time.Second,
+	}
+
+	if cfg.Retry.Enabled {
+		if cfg.Retry.MaxAttempts > 0 {
+			out.MaxAttempts = cfg.Retry.MaxAttempts
+		}
+		if cfg.Retry.InitialDelayMs > 0 {
+			out.InitialDelay = time.Duration(cfg.Retry.InitialDelayMs) * time.Millisecond
+		}
+		if cfg.Retry.MaxDelayMs > 0 {
+			out.MaxDelay = time.Duration(cfg.Retry.MaxDelayMs) * time.Millisecond
+		}
+	}
+
+	if out.MaxAttempts < 1 {
+		out.MaxAttempts = 1
+	}
+	if out.InitialDelay <= 0 {
+		out.InitialDelay = 300 * time.Millisecond
+	}
+	if out.MaxDelay < out.InitialDelay {
+		out.MaxDelay = out.InitialDelay
+	}
+
+	return out
+}
+
+func shouldRetryTransportError(err error, cfg Config) bool {
+	if err == nil {
+		return false
+	}
+	// 外层 context 被取消/超时，通常代表调用方主动结束，不应继续重试。
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	var nerr net.Error
+	if errors.As(err, &nerr) && nerr.Timeout() {
+		// 如果配置了 retry 规则，尊重 retry_on_timeout；否则默认对网络超时重试。
+		if cfg.Retry.Enabled {
+			return cfg.Retry.RetryOnTimeout
+		}
+		return true
+	}
+
+	s := strings.ToLower(err.Error())
+	if strings.Contains(s, "tls: bad record mac") {
+		return true
+	}
+	if strings.Contains(s, "local error: tls") {
+		return true
+	}
+	if strings.Contains(s, "connection reset") ||
+		strings.Contains(s, "connection refused") ||
+		strings.Contains(s, "broken pipe") ||
+		strings.Contains(s, "http2: client connection lost") ||
+		strings.Contains(s, "use of closed network connection") ||
+		strings.Contains(s, "unexpected eof") {
+		return true
+	}
+	if strings.Contains(s, "timeout") {
+		if cfg.Retry.Enabled {
+			return cfg.Retry.RetryOnTimeout
+		}
+		return true
+	}
+	return false
+}
+
+func retryDelay(settings openAIRetrySettings, attempt int) time.Duration {
+	delay := settings.InitialDelay
+	// attempt=1 对应第一次重试延迟；attempt>1 指数退避。
+	for i := 1; i < attempt; i++ {
+		delay *= 2
+		if delay >= settings.MaxDelay {
+			return settings.MaxDelay
+		}
+	}
+	if delay > settings.MaxDelay {
+		return settings.MaxDelay
+	}
+	return delay
+}
+
+func doOpenAIRequest(ctx context.Context, cfg Config, body []byte) (*http.Response, error) {
+	settings := resolveOpenAIRetrySettings(cfg)
+	url := strings.TrimRight(cfg.APIBase, "/") + "/chat/completions"
+
+	var lastErr error
+	for attempt := 1; attempt <= settings.MaxAttempts; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("create request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
+		for k, v := range cfg.ExtraHeaders {
+			req.Header.Set(k, v)
+		}
+
+		// 重试时强制新连接，避免复用潜在损坏的 TLS/HTTP2 长连接。
+		if attempt > 1 {
+			req.Close = true
+			if tr, ok := openAIHTTPClient.Transport.(*http.Transport); ok {
+				tr.CloseIdleConnections()
+			}
+		}
+
+		resp, err := openAIHTTPClient.Do(req)
+		if err == nil {
+			return resp, nil
+		}
+
+		lastErr = err
+		if attempt == settings.MaxAttempts || !shouldRetryTransportError(err, cfg) {
+			return nil, fmt.Errorf("send request: %w", err)
+		}
+
+		delay := retryDelay(settings, attempt)
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return nil, fmt.Errorf("send request: %w", ctx.Err())
+		case <-timer.C:
+		}
+	}
+
+	return nil, fmt.Errorf("send request: %w", lastErr)
+}
+
 // callOpenAI 执行 OpenAI API 调用（非流式）
 // 支持文本响应和工具调用解析
 func callOpenAI(ctx context.Context, cfg Config, messages []Message, opts CallOptions) (*Response, error) {
@@ -130,21 +300,9 @@ func callOpenAI(ctx context.Context, cfg Config, messages []Message, opts CallOp
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", cfg.APIBase+"/chat/completions", bytes.NewReader(body))
+	resp, err := doOpenAIRequest(ctx, cfg, body)
 	if err != nil {
-		return nil, fmt.Errorf("create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
-
-	// v0.56.0: 添加额外请求头（如 User-Agent）
-	for k, v := range cfg.ExtraHeaders {
-		req.Header.Set(k, v)
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("send request: %w", err)
+		return nil, err
 	}
 	defer resp.Body.Close()
 
@@ -318,22 +476,9 @@ func callOpenAIStream(ctx context.Context, cfg Config, messages []Message, opts 
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", cfg.APIBase+"/chat/completions", bytes.NewReader(body))
+	resp, err := doOpenAIRequest(ctx, cfg, body)
 	if err != nil {
-		return nil, fmt.Errorf("create request: %w", err)
-	}
-	req = req.WithContext(ctx)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
-
-	// v0.56.0: 添加额外请求头（如 User-Agent）
-	for k, v := range cfg.ExtraHeaders {
-		req.Header.Set(k, v)
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("send request: %w", err)
+		return nil, err
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/internal/provider/openai_stream_retry_test.go
+++ b/internal/provider/openai_stream_retry_test.go
@@ -77,3 +77,14 @@ func TestDoOpenAIRequestRetriesOnTransportError(t *testing.T) {
 		t.Fatal("retry attempt should force close connection")
 	}
 }
+
+func TestNewOpenAITransportKeepsHTTP2Enabled(t *testing.T) {
+	rt := newOpenAITransport()
+	tr, ok := rt.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", rt)
+	}
+	if !tr.ForceAttemptHTTP2 {
+		t.Fatal("expected ForceAttemptHTTP2 to be enabled")
+	}
+}

--- a/internal/provider/openai_stream_retry_test.go
+++ b/internal/provider/openai_stream_retry_test.go
@@ -1,0 +1,79 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestShouldRetryTransportErrorBadRecordMAC(t *testing.T) {
+	cfg := Config{}
+	err := fmt.Errorf("local error: tls: bad record MAC")
+	if !shouldRetryTransportError(err, cfg) {
+		t.Fatal("expected bad record MAC to be retryable")
+	}
+}
+
+func TestDoOpenAIRequestRetriesOnTransportError(t *testing.T) {
+	orig := openAIHTTPClient
+	t.Cleanup(func() {
+		openAIHTTPClient = orig
+	})
+
+	attempts := 0
+	closeFlags := make([]bool, 0, 2)
+	openAIHTTPClient = &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			closeFlags = append(closeFlags, req.Close)
+			if attempts == 1 {
+				return nil, fmt.Errorf("local error: tls: bad record MAC")
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+				Request:    req,
+			}, nil
+		}),
+	}
+
+	cfg := Config{
+		APIBase: "https://api.boaiak.com/v1",
+		APIKey:  "sk-test",
+		Retry: RetryConfig{
+			Enabled:        true,
+			MaxAttempts:    2,
+			InitialDelayMs: 1,
+			MaxDelayMs:     1,
+		},
+	}
+
+	resp, err := doOpenAIRequest(context.Background(), cfg, []byte(`{"model":"x"}`))
+	if err != nil {
+		t.Fatalf("doOpenAIRequest returned error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if attempts != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts)
+	}
+	if len(closeFlags) < 2 {
+		t.Fatalf("expected 2 close flags, got %d", len(closeFlags))
+	}
+	if closeFlags[0] {
+		t.Fatal("first attempt should not force close connection")
+	}
+	if !closeFlags[1] {
+		t.Fatal("retry attempt should force close connection")
+	}
+}

--- a/internal/provider/v048_test.go
+++ b/internal/provider/v048_test.go
@@ -963,9 +963,9 @@ func TestModelCatalogRegisterOverwrite(t *testing.T) {
 
 	// Register custom model with same ID as default
 	custom := ModelInfo{
-		ID:          "gpt-4o",
-		Provider:    "custom",
-		DisplayName: "Custom GPT-4o",
+		ID:           "gpt-4o",
+		Provider:     "custom",
+		DisplayName:  "Custom GPT-4o",
 		Capabilities: []string{"chat"},
 	}
 	catalog.Register(custom)
@@ -1054,6 +1054,22 @@ func TestToOpenAIMessagesWithToolCallIDAndName(t *testing.T) {
 	}
 	if result[0].Name != "get_weather" {
 		t.Errorf("expected name 'get_weather', got %s", result[0].Name)
+	}
+}
+
+func TestToOpenAIMessagesToolWithoutCallIDFallbackToAssistant(t *testing.T) {
+	msgs := []Message{
+		{Role: "tool", Content: "legacy tool result", Name: "web_search"},
+	}
+	result := toOpenAIMessages(msgs)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(result))
+	}
+	if result[0].Role != "assistant" {
+		t.Fatalf("expected fallback role assistant, got %s", result[0].Role)
+	}
+	if result[0].ToolCallID != "" {
+		t.Fatalf("expected empty tool_call_id in fallback message, got %q", result[0].ToolCallID)
 	}
 }
 
@@ -1576,7 +1592,7 @@ func TestProviderValidatePartial(t *testing.T) {
 func TestOpenAIProviderName(t *testing.T) {
 	cfg := Config{
 		Name:   "openai",
-		APIKey : "sk-test",
+		APIKey: "sk-test",
 		Model:  "gpt-4",
 	}
 	prov := NewOpenAIProvider(cfg)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -627,17 +627,6 @@ func (s *Server) doChatSync(w http.ResponseWriter, r *http.Request, req ChatRequ
 		}
 	}
 
-	result, err := s.agent.RunLoop(ctx, req.Message, loopCfg)
-	if err != nil {
-		s.stats.mu.Lock()
-		s.stats.ErrorReqs++
-		s.stats.mu.Unlock()
-		s.sendError(w, "chat failed", http.StatusInternalServerError, err.Error())
-		return
-	}
-
-	duration := time.Since(start)
-
 	// v0.24.1: 如果没有提供 session_id，创建新会话
 	sessionID := req.SessionID
 	var sess *session.Session
@@ -654,7 +643,11 @@ func (s *Server) doChatSync(w http.ResponseWriter, r *http.Request, req ChatRequ
 		}
 	}
 
-	// 使用 RunLoopWithSession 确保消息被保存
+	// 使用 RunLoopWithSession 确保消息被保存；无法创建/获取会话时降级为无会话 RunLoop
+	var (
+		result *agent.LoopResult
+		err    error
+	)
 	if sess != nil {
 		loopCfgWithSession := agent.LoopConfig{
 			MaxIterations: loopCfg.MaxIterations,
@@ -662,14 +655,18 @@ func (s *Server) doChatSync(w http.ResponseWriter, r *http.Request, req ChatRequ
 			AutoApprove:   loopCfg.AutoApprove,
 		}
 		result, err = s.agent.RunLoopWithSession(ctx, sess, req.Message, loopCfgWithSession)
-		if err != nil {
-			s.stats.mu.Lock()
-			s.stats.ErrorReqs++
-			s.stats.mu.Unlock()
-			s.sendError(w, "chat failed", http.StatusInternalServerError, err.Error())
-			return
-		}
+	} else {
+		result, err = s.agent.RunLoop(ctx, req.Message, loopCfg)
 	}
+	if err != nil {
+		s.stats.mu.Lock()
+		s.stats.ErrorReqs++
+		s.stats.mu.Unlock()
+		s.sendError(w, "chat failed", http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	duration := time.Since(start)
 
 	resp := ChatResponse{
 		Response:   result.Response,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -15,13 +16,13 @@ import (
 	"github.com/yurika0211/luckyharness/internal/collab"
 	"github.com/yurika0211/luckyharness/internal/contextx"
 	"github.com/yurika0211/luckyharness/internal/gateway"
+	"github.com/yurika0211/luckyharness/internal/gateway/telegram"
 	"github.com/yurika0211/luckyharness/internal/health"
 	"github.com/yurika0211/luckyharness/internal/memory"
 	"github.com/yurika0211/luckyharness/internal/metrics"
 	"github.com/yurika0211/luckyharness/internal/provider"
 	"github.com/yurika0211/luckyharness/internal/session"
 	"github.com/yurika0211/luckyharness/internal/tool"
-	"github.com/yurika0211/luckyharness/internal/gateway/telegram"
 	"github.com/yurika0211/luckyharness/internal/websocket"
 	"github.com/yurika0211/luckyharness/internal/workflow"
 )
@@ -48,8 +49,8 @@ type Server struct {
 	wsHub *websocket.Hub
 
 	// v0.22.0: 多 Agent 协作
-	collabRegistry   *collab.Registry
-	delegateManager  *collab.DelegateManager
+	collabRegistry  *collab.Registry
+	delegateManager *collab.DelegateManager
 
 	// v0.24.0: Workflow Engine
 	workflowEngine *workflow.WorkflowEngine
@@ -62,9 +63,9 @@ type ServerConfig struct {
 	EnableCORS  bool     `yaml:"enable_cors,omitempty"`  // 启用 CORS，默认 true
 	CORSOrigins []string `yaml:"cors_origins,omitempty"` // CORS 允许的源
 	RateLimit   int      `yaml:"rate_limit,omitempty"`   // 每分钟请求限制，默认 60
-	MetricsAddr string   `yaml:"metrics_addr,omitempty"`  // Prometheus metrics 独立端口（空=复用主端口）
-	LogLevel    string   `yaml:"log_level,omitempty"`     // 日志级别: debug, info, warn, error
-	LogFormat   string   `yaml:"log_format,omitempty"`    // 日志格式: json, text
+	MetricsAddr string   `yaml:"metrics_addr,omitempty"` // Prometheus metrics 独立端口（空=复用主端口）
+	LogLevel    string   `yaml:"log_level,omitempty"`    // 日志级别: debug, info, warn, error
+	LogFormat   string   `yaml:"log_format,omitempty"`   // 日志格式: json, text
 }
 
 // DefaultServerConfig 返回默认配置
@@ -81,32 +82,32 @@ func DefaultServerConfig() ServerConfig {
 
 // ServerStats 服务器统计
 type ServerStats struct {
-	mu           sync.RWMutex
-	TotalReqs    int64
-	ChatReqs     int64
-	ErrorReqs    int64
-	StartTime    time.Time
-	LastReqTime  time.Time
+	mu          sync.RWMutex
+	TotalReqs   int64
+	ChatReqs    int64
+	ErrorReqs   int64
+	StartTime   time.Time
+	LastReqTime time.Time
 }
 
 // ChatRequest 聊天请求
 type ChatRequest struct {
-	Message    string            `json:"message"`
-	SessionID  string            `json:"session_id,omitempty"`
-	Stream     bool              `json:"stream,omitempty"`
-	MaxIter    int               `json:"max_iterations,omitempty"`
-	AutoApprove bool             `json:"auto_approve,omitempty"`
-	Metadata   map[string]string `json:"metadata,omitempty"`
+	Message     string            `json:"message"`
+	SessionID   string            `json:"session_id,omitempty"`
+	Stream      bool              `json:"stream,omitempty"`
+	MaxIter     int               `json:"max_iterations,omitempty"`
+	AutoApprove bool              `json:"auto_approve,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
 }
 
 // ChatResponse 聊天响应
 type ChatResponse struct {
-	Response   string        `json:"response"`
-	SessionID  string        `json:"session_id"`
-	Iterations int           `json:"iterations"`
-	TokensUsed int           `json:"tokens_used"`
+	Response   string         `json:"response"`
+	SessionID  string         `json:"session_id"`
+	Iterations int            `json:"iterations"`
+	TokensUsed int            `json:"tokens_used"`
 	ToolCalls  []toolCallInfo `json:"tool_calls,omitempty"`
-	Duration   string        `json:"duration"`
+	Duration   string         `json:"duration"`
 }
 
 type toolCallInfo struct {
@@ -565,7 +566,7 @@ func (s *Server) doChatSync(w http.ResponseWriter, r *http.Request, req ChatRequ
 		// if len(parts) > 1 {
 		// 	args = parts[1]
 		// }
-		
+
 		// 简单命令处理（不依赖 gateway handler）
 		switch cmd {
 		case "help":
@@ -625,7 +626,7 @@ func (s *Server) doChatSync(w http.ResponseWriter, r *http.Request, req ChatRequ
 			return
 		}
 	}
-	
+
 	result, err := s.agent.RunLoop(ctx, req.Message, loopCfg)
 	if err != nil {
 		s.stats.mu.Lock()
@@ -700,10 +701,10 @@ func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {
 	// Agent 暴露 session manager
 	sessions := s.agent.Sessions().List()
 	type sessionInfo struct {
-		ID        string `json:"id"`
-		MessageCount int  `json:"message_count"`
-		CreatedAt string `json:"created_at"`
-		UpdatedAt string `json:"updated_at"`
+		ID           string `json:"id"`
+		MessageCount int    `json:"message_count"`
+		CreatedAt    string `json:"created_at"`
+		UpdatedAt    string `json:"updated_at"`
 	}
 
 	var infos []sessionInfo
@@ -913,7 +914,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleWSStats(w http.ResponseWriter, r *http.Request) {
 	if s.wsHub == nil {
 		s.sendJSON(w, http.StatusOK, map[string]interface{}{
-			"enabled":       false,
+			"enabled":        false,
 			"active_conns":   0,
 			"total_conns":    0,
 			"total_messages": 0,
@@ -924,9 +925,9 @@ func (s *Server) handleWSStats(w http.ResponseWriter, r *http.Request) {
 
 	stats := s.wsHub.GetStats()
 	s.sendJSON(w, http.StatusOK, map[string]interface{}{
-		"enabled":       true,
-		"active_conns":  stats.ActiveConns,
-		"total_conns":   stats.TotalConns,
+		"enabled":        true,
+		"active_conns":   stats.ActiveConns,
+		"total_conns":    stats.TotalConns,
 		"total_messages": stats.TotalMessages,
 		"errors":         stats.Errors,
 		"sessions":       s.wsHub.SessionCount(),
@@ -941,8 +942,8 @@ func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.sendJSON(w, http.StatusOK, map[string]interface{}{
-		"name":     "LuckyHarness API",
-		"version":  "v0.21.0",
+		"name":    "LuckyHarness API",
+		"version": "v0.21.0",
 		"endpoints": []string{
 			"POST /api/v1/chat       — 流式聊天 (SSE)",
 			"POST /api/v1/chat/sync  — 同步聊天",
@@ -1173,8 +1174,8 @@ type rateLimiter struct {
 }
 
 type clientBucket struct {
-	count    int
-	resetAt  time.Time
+	count   int
+	resetAt time.Time
 }
 
 func newRateLimiter(limit int) *rateLimiter {
@@ -1242,14 +1243,14 @@ func (s *Server) handleContext(w http.ResponseWriter, r *http.Request) {
 	cfg := cw.Config()
 
 	s.sendJSON(w, http.StatusOK, map[string]interface{}{
-		"max_tokens":        cfg.MaxTokens,
-		"reserved_tokens":  cfg.ReservedTokens,
-		"available_tokens": cfg.MaxTokens - cfg.ReservedTokens,
-		"strategy":          cfg.Strategy.String(),
-		"sliding_window_size": cfg.SlidingWindowSize,
+		"max_tokens":             cfg.MaxTokens,
+		"reserved_tokens":        cfg.ReservedTokens,
+		"available_tokens":       cfg.MaxTokens - cfg.ReservedTokens,
+		"strategy":               cfg.Strategy.String(),
+		"sliding_window_size":    cfg.SlidingWindowSize,
 		"max_conversation_turns": cfg.MaxConversationTurns,
-		"memory_budget":    cfg.MemoryBudget,
-		"summarize_threshold": cfg.SummarizeThreshold,
+		"memory_budget":          cfg.MemoryBudget,
+		"summarize_threshold":    cfg.SummarizeThreshold,
 	})
 }
 
@@ -1262,10 +1263,10 @@ func (s *Server) handleContextFit(w http.ResponseWriter, r *http.Request) {
 
 	var req struct {
 		Messages []struct {
-			Role      string `json:"role"`
-			Content   string `json:"content"`
-			Priority  int    `json:"priority,omitempty"`
-			Category  string `json:"category,omitempty"`
+			Role     string `json:"role"`
+			Content  string `json:"content"`
+			Priority int    `json:"priority,omitempty"`
+			Category string `json:"category,omitempty"`
 		} `json:"messages"`
 		Strategy string `json:"strategy,omitempty"` // oldest_first, low_priority_first, sliding_window, summarize
 	}
@@ -1305,28 +1306,28 @@ func (s *Server) handleContextFit(w http.ResponseWriter, r *http.Request) {
 		switch req.Strategy {
 		case "oldest_first":
 			cw = contextx.NewContextWindow(contextx.WindowConfig{
-				MaxTokens:       cw.Config().MaxTokens,
-				ReservedTokens:  cw.Config().ReservedTokens,
-				Strategy:        contextx.TrimOldest,
+				MaxTokens:      cw.Config().MaxTokens,
+				ReservedTokens: cw.Config().ReservedTokens,
+				Strategy:       contextx.TrimOldest,
 			})
 		case "low_priority_first":
 			cw = contextx.NewContextWindow(contextx.WindowConfig{
-				MaxTokens:       cw.Config().MaxTokens,
-				ReservedTokens:  cw.Config().ReservedTokens,
-				Strategy:        contextx.TrimLowPriority,
+				MaxTokens:      cw.Config().MaxTokens,
+				ReservedTokens: cw.Config().ReservedTokens,
+				Strategy:       contextx.TrimLowPriority,
 			})
 		case "sliding_window":
 			cw = contextx.NewContextWindow(contextx.WindowConfig{
-				MaxTokens:          cw.Config().MaxTokens,
-				ReservedTokens:      cw.Config().ReservedTokens,
-				Strategy:            contextx.TrimSlidingWindow,
-				SlidingWindowSize:   cw.Config().SlidingWindowSize,
+				MaxTokens:         cw.Config().MaxTokens,
+				ReservedTokens:    cw.Config().ReservedTokens,
+				Strategy:          contextx.TrimSlidingWindow,
+				SlidingWindowSize: cw.Config().SlidingWindowSize,
 			})
 		case "summarize":
 			cw = contextx.NewContextWindow(contextx.WindowConfig{
-				MaxTokens:       cw.Config().MaxTokens,
-				ReservedTokens:  cw.Config().ReservedTokens,
-				Strategy:        contextx.TrimSummarize,
+				MaxTokens:      cw.Config().MaxTokens,
+				ReservedTokens: cw.Config().ReservedTokens,
+				Strategy:       contextx.TrimSummarize,
 			})
 		}
 	}
@@ -1338,23 +1339,23 @@ func (s *Server) handleContextFit(w http.ResponseWriter, r *http.Request) {
 	resultMessages := make([]map[string]interface{}, len(fitted))
 	for i, msg := range fitted {
 		resultMessages[i] = map[string]interface{}{
-			"role":      msg.Role,
-			"content":   msg.Content,
-			"priority":  int(msg.Priority),
-			"category":  msg.Category,
+			"role":     msg.Role,
+			"content":  msg.Content,
+			"priority": int(msg.Priority),
+			"category": msg.Category,
 		}
 	}
 
 	s.sendJSON(w, http.StatusOK, map[string]interface{}{
-		"trimmed":         trimResult.Trimmed,
-		"original_count":  trimResult.OriginalCount,
-		"original_tokens": trimResult.OriginalTokens,
-		"final_count":     trimResult.FinalCount,
-		"final_tokens":    trimResult.FinalTokens,
+		"trimmed":          trimResult.Trimmed,
+		"original_count":   trimResult.OriginalCount,
+		"original_tokens":  trimResult.OriginalTokens,
+		"final_count":      trimResult.FinalCount,
+		"final_tokens":     trimResult.FinalTokens,
 		"available_tokens": trimResult.AvailableTokens,
-		"strategy":        trimResult.Strategy.String(),
-		"messages":        resultMessages,
-		"summary":         trimResult.Summary(),
+		"strategy":         trimResult.Strategy.String(),
+		"messages":         resultMessages,
+		"summary":          trimResult.Summary(),
 	})
 }
 
@@ -1366,9 +1367,9 @@ func (s *Server) handleRAGIndex(w http.ResponseWriter, r *http.Request) {
 	case http.MethodPost:
 		var req struct {
 			Source  string `json:"source"`            // 文件路径或来源标识
-			Title   string `json:"title,omitempty"`  // 文档标题（索引文本时使用）
+			Title   string `json:"title,omitempty"`   // 文档标题（索引文本时使用）
 			Content string `json:"content,omitempty"` // 文本内容（索引文本时使用）
-			Dir     string `json:"dir,omitempty"`    // 目录路径（批量索引时使用）
+			Dir     string `json:"dir,omitempty"`     // 目录路径（批量索引时使用）
 		}
 
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -1395,10 +1396,10 @@ func (s *Server) handleRAGIndex(w http.ResponseWriter, r *http.Request) {
 				docIDs[i] = d.ID
 			}
 			result = map[string]interface{}{
-				"action":   "index_directory",
-				"dir":      req.Dir,
-				"indexed":  len(docs),
-				"doc_ids":  docIDs,
+				"action":  "index_directory",
+				"dir":     req.Dir,
+				"indexed": len(docs),
+				"doc_ids": docIDs,
 			}
 		} else if req.Content != "" {
 			// 索引文本内容
@@ -1412,10 +1413,10 @@ func (s *Server) handleRAGIndex(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			result = map[string]interface{}{
-				"action":    "index_text",
-				"doc_id":    doc.ID,
-				"title":     doc.Title,
-				"chunks":    len(doc.Chunks),
+				"action":     "index_text",
+				"doc_id":     doc.ID,
+				"title":      doc.Title,
+				"chunks":     len(doc.Chunks),
 				"indexed_at": doc.IndexedAt,
 			}
 		} else if req.Source != "" {
@@ -1426,10 +1427,10 @@ func (s *Server) handleRAGIndex(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			result = map[string]interface{}{
-				"action":    "index_file",
-				"doc_id":    doc.ID,
-				"title":     doc.Title,
-				"chunks":    len(doc.Chunks),
+				"action":     "index_file",
+				"doc_id":     doc.ID,
+				"title":      doc.Title,
+				"chunks":     len(doc.Chunks),
 				"indexed_at": doc.IndexedAt,
 			}
 		} else {
@@ -1471,10 +1472,10 @@ func (s *Server) handleRAGSearch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-		Query  string  `json:"query"`
-		TopK   int     `json:"top_k,omitempty"`
+		Query    string  `json:"query"`
+		TopK     int     `json:"top_k,omitempty"`
 		MinScore float64 `json:"min_score,omitempty"`
-		Source string  `json:"source,omitempty"` // 按来源过滤
+		Source   string  `json:"source,omitempty"` // 按来源过滤
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -1578,9 +1579,9 @@ func (s *Server) handleRAGStats(w http.ResponseWriter, r *http.Request) {
 		"sources":        stats.Sources,
 		"documents":      docs,
 		"retriever": map[string]interface{}{
-			"top_k":     ragMgr.RetrieverConfig().TopK,
-			"min_score": ragMgr.RetrieverConfig().MinScore,
-			"use_mmr":   ragMgr.RetrieverConfig().UseMMR,
+			"top_k":      ragMgr.RetrieverConfig().TopK,
+			"min_score":  ragMgr.RetrieverConfig().MinScore,
+			"use_mmr":    ragMgr.RetrieverConfig().UseMMR,
 			"mmr_lambda": ragMgr.RetrieverConfig().MMRLambda,
 		},
 	})
@@ -1598,7 +1599,7 @@ func (s *Server) handleFunctionCalling(w http.ResponseWriter, r *http.Request) {
 			"version":     "0.20.0",
 			"description": "OpenAI Function Calling support",
 			"endpoints": map[string]string{
-				"POST /api/v1/fc":        "Execute function calling",
+				"POST /api/v1/fc":         "Execute function calling",
 				"GET  /api/v1/fc/tools":   "List available function tools",
 				"GET  /api/v1/fc/history": "Get function call history",
 			},
@@ -1715,12 +1716,12 @@ type fcRequest struct {
 
 // fcResponse 是 function calling 响应
 type fcResponse struct {
-	Response   string        `json:"response"`
-	Iterations int           `json:"iterations"`
-	TokensUsed int           `json:"tokens_used"`
+	Response   string         `json:"response"`
+	Iterations int            `json:"iterations"`
+	TokensUsed int            `json:"tokens_used"`
 	ToolCalls  []toolCallInfo `json:"tool_calls,omitempty"`
-	Duration   string        `json:"duration"`
-	State      string        `json:"state"`
+	Duration   string         `json:"duration"`
+	State      string         `json:"state"`
 }
 
 // --- v0.21.0: RAG 持久化存储 API ---
@@ -1737,8 +1738,8 @@ func (s *Server) handleRAGStore(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		// 获取存储后端信息
 		result := map[string]interface{}{
-			"backend":  "memory",
-			"sqlite":   false,
+			"backend": "memory",
+			"sqlite":  false,
 		}
 
 		if ragMgr.IsSQLite() {
@@ -1749,11 +1750,11 @@ func (s *Server) handleRAGStore(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			result = map[string]interface{}{
-				"backend":  "sqlite",
-				"sqlite":   true,
-				"db_path":  sqlStore.Path(),
-				"entries":  count,
-				"db_size":  dbSize,
+				"backend":   "sqlite",
+				"sqlite":    true,
+				"db_path":   sqlStore.Path(),
+				"entries":   count,
+				"db_size":   dbSize,
 				"dimension": sqlStore.Dimension(),
 			}
 		} else {
@@ -1809,10 +1810,10 @@ func (s *Server) handleWorkflows(w http.ResponseWriter, r *http.Request) {
 
 	case http.MethodPost:
 		var req struct {
-			Name        string              `json:"name"`
-			Description string              `json:"description,omitempty"`
-			Tasks       []*workflow.Task    `json:"tasks"`
-			Version     string              `json:"version,omitempty"`
+			Name        string           `json:"name"`
+			Description string           `json:"description,omitempty"`
+			Tasks       []*workflow.Task `json:"tasks"`
+			Version     string           `json:"version,omitempty"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			s.sendError(w, "invalid request body", http.StatusBadRequest, err.Error())
@@ -1988,6 +1989,8 @@ func (s *Server) handleGatewayTelegramStart(w http.ResponseWriter, r *http.Reque
 		AdminIDs:     req.AdminIDs,
 	})
 	handler := telegram.NewHandler(tgAdapter, s.agent)
+	// 与 CLI 路径保持一致：持久化 chatID→sessionID 映射，重启后恢复会话
+	handler.SetDataDir(filepath.Join(s.agent.Config().HomeDir(), "data", "telegram"))
 	tgAdapter.SetHandler(func(ctx context.Context, msg *gateway.Message) error {
 		return handler.HandleMessage(ctx, msg)
 	})
@@ -2055,7 +2058,7 @@ func formatDuration(d time.Duration) string {
 	days := int(d.Hours() / 24)
 	hours := int(d.Hours()) % 24
 	mins := int(d.Minutes()) % 60
-	
+
 	if days > 0 {
 		return fmt.Sprintf("%dd %dh %dm", days, hours, mins)
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3,8 +3,10 @@ package server
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -308,6 +310,61 @@ func TestHandleChatSyncInvalidBody(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleChatSyncRunsLoopOncePerRequest(t *testing.T) {
+	var callCount atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			http.NotFound(w, r)
+			return
+		}
+		callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"ok"}}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+	}))
+	defer upstream.Close()
+
+	tmpDir := t.TempDir()
+	mgr, err := config.NewManagerWithDir(tmpDir)
+	if err != nil {
+		t.Fatalf("create config manager: %v", err)
+	}
+	if err := mgr.Set("provider", "openai"); err != nil {
+		t.Fatalf("set provider: %v", err)
+	}
+	if err := mgr.Set("api_key", "sk-test"); err != nil {
+		t.Fatalf("set api_key: %v", err)
+	}
+	if err := mgr.Set("api_base", upstream.URL); err != nil {
+		t.Fatalf("set api_base: %v", err)
+	}
+	if err := mgr.Set("model", "gpt-4o-mini"); err != nil {
+		t.Fatalf("set model: %v", err)
+	}
+
+	a, err := agent.New(mgr)
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	s := New(a, DefaultServerConfig())
+
+	body := map[string]any{
+		"message": "hello",
+	}
+	data, _ := json.Marshal(body)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/chat/sync", bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.handleChatSync(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d, body=%s", w.Code, w.Body.String())
+	}
+	if got := callCount.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 upstream call, got %d", got)
 	}
 }
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -101,8 +101,8 @@ func NewSession(id, dir string) *Session {
 	}
 }
 
-// AddMessage 添加消息
-func (s *Session) AddMessage(role, content string) {
+// AddProviderMessage 添加完整 provider 消息（保留 tool_calls / tool_call_id 等结构化字段）
+func (s *Session) AddProviderMessage(msg provider.Message) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -112,13 +112,13 @@ func (s *Session) AddMessage(role, content string) {
 		s.messagesLoaded = true
 	}
 
-	s.Messages = append(s.Messages, provider.Message{Role: role, Content: content})
+	s.Messages = append(s.Messages, msg)
 	s.messageCount = len(s.Messages)
 	s.UpdatedAt = time.Now()
 
 	// 自动生成标题：取第一条用户消息的前 50 字符
-	if s.Title == "" && role == "user" {
-		title := content
+	if s.Title == "" && msg.Role == "user" {
+		title := msg.Content
 		if len(title) > 50 {
 			title = title[:50] + "..."
 		}
@@ -126,23 +126,28 @@ func (s *Session) AddMessage(role, content string) {
 	}
 }
 
+// AddMessage 添加消息
+func (s *Session) AddMessage(role, content string) {
+	s.AddProviderMessage(provider.Message{Role: role, Content: content})
+}
+
 // AddToolMessage 添加工具结果消息
 func (s *Session) AddToolMessage(toolName, result string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	// 确保消息已加载
-	if !s.messagesLoaded {
-		s.Messages = make([]provider.Message, 0)
-		s.messagesLoaded = true
-	}
-
-	s.Messages = append(s.Messages, provider.Message{
+	s.AddProviderMessage(provider.Message{
 		Role:    "tool",
 		Content: fmt.Sprintf("[Tool: %s] %s", toolName, result),
+		Name:    toolName,
 	})
-	s.messageCount = len(s.Messages)
-	s.UpdatedAt = time.Now()
+}
+
+// AddToolMessageWithCallID 添加带 tool_call_id 的工具结果消息（function calling 兼容）
+func (s *Session) AddToolMessageWithCallID(callID, toolName, result string) {
+	s.AddProviderMessage(provider.Message{
+		Role:       "tool",
+		Content:    result,
+		ToolCallID: callID,
+		Name:       toolName,
+	})
 }
 
 // GetMessages 获取消息（懒加载 + 滑动窗口）
@@ -240,12 +245,12 @@ func (s *Session) Save() error {
 
 // sessionData 是 JSON 序列化格式
 type sessionData struct {
-	ID           string            `json:"id"`
-	Title        string            `json:"title"`
+	ID           string             `json:"id"`
+	Title        string             `json:"title"`
 	Messages     []provider.Message `json:"messages"`
-	CreatedAt    time.Time         `json:"created_at"`
-	UpdatedAt    time.Time         `json:"updated_at"`
-	ShellContext ShellContext      `json:"shell_context"`
+	CreatedAt    time.Time          `json:"created_at"`
+	UpdatedAt    time.Time          `json:"updated_at"`
+	ShellContext ShellContext       `json:"shell_context"`
 }
 
 // sessionMeta 是仅元数据的轻量格式（用于启动时批量加载）
@@ -255,7 +260,7 @@ type sessionMeta struct {
 	MessageCount int          `json:"message_count"`
 	CreatedAt    time.Time    `json:"created_at"`
 	UpdatedAt    time.Time    `json:"updated_at"`
-	ShellContext ShellContext  `json:"shell_context"`
+	ShellContext ShellContext `json:"shell_context"`
 }
 
 // SessionInfo 是会话的摘要信息（用于列表展示）

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -2,6 +2,8 @@ package session
 
 import (
 	"testing"
+
+	"github.com/yurika0211/luckyharness/internal/provider"
 )
 
 func TestNewSession(t *testing.T) {
@@ -53,6 +55,27 @@ func TestAddToolMessage(t *testing.T) {
 	}
 	if msgs[0].Role != "tool" {
 		t.Errorf("expected tool role, got %s", msgs[0].Role)
+	}
+}
+
+func TestAddProviderMessagePreservesToolCallFields(t *testing.T) {
+	s := NewSession("test-provider-message", t.TempDir())
+	s.AddProviderMessage(provider.Message{
+		Role:       "tool",
+		Content:    "42",
+		ToolCallID: "call_abc123",
+		Name:       "calculator",
+	})
+
+	msgs := s.GetMessages()
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if msgs[0].ToolCallID != "call_abc123" {
+		t.Fatalf("expected tool_call_id call_abc123, got %q", msgs[0].ToolCallID)
+	}
+	if msgs[0].Name != "calculator" {
+		t.Fatalf("expected name calculator, got %q", msgs[0].Name)
 	}
 }
 

--- a/internal/tool/skill_loader.go
+++ b/internal/tool/skill_loader.go
@@ -58,7 +58,6 @@ func (sl *SkillLoader) LoadAll() ([]*SkillInfo, error) {
 		if err != nil {
 			continue // 跳过无法加载的
 		}
-		info.Dir = skillDir
 		skills = append(skills, info)
 	}
 
@@ -79,6 +78,7 @@ func (sl *SkillLoader) Load(path string) (*SkillInfo, error) {
 
 	// 解析 Skill 名称（从目录名）
 	dir := filepath.Dir(path)
+	info.Dir = dir
 	dirName := filepath.Base(dir)
 	info.Name = sanitizeName(dirName)
 

--- a/internal/tool/skill_loader_test.go
+++ b/internal/tool/skill_loader_test.go
@@ -145,3 +145,46 @@ func TestParseToolEntry(t *testing.T) {
 		}
 	}
 }
+
+func TestSkillLoaderAutoGenerateToolsFromScripts(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillDir := filepath.Join(tmpDir, "script-skill")
+	scriptsDir := filepath.Join(skillDir, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0755); err != nil {
+		t.Fatalf("mkdir scripts: %v", err)
+	}
+
+	// 不提供 Tools section，触发 autoGenerateTools
+	skillContent := "# Script Skill\n\nSkill with script only.\n"
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillContent), 0644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scriptsDir, "calc.sh"), []byte("#!/bin/sh\necho ok\n"), 0755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	loader := NewSkillLoader(tmpDir)
+	skills, err := loader.LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(skills))
+	}
+
+	var hasRun, hasCalc bool
+	for _, tool := range skills[0].Tools {
+		if tool.Name == "run" {
+			hasRun = true
+		}
+		if tool.Name == "calc" {
+			hasCalc = true
+		}
+	}
+	if !hasRun {
+		t.Fatal("expected auto-generated run tool")
+	}
+	if !hasCalc {
+		t.Fatal("expected auto-generated script tool 'calc'")
+	}
+}


### PR DESCRIPTION

## 2. 背景

本 PR 聚焦三类问题：

- 消息网关 CLI 的 `status/stop` 只能看当前进程内状态，跨进程不可用。
- Telegram `/stop`、`/restart` 是占位行为，无法真实取消任务/重连。
- Agent 在工具调用场景可能出现重复调用循环，导致迭代浪费或超时。

同时包含一批配置与稳定性改进，统一 CLI/Server 对 `config.json` 的读取行为，并补充回归测试。

## 3. 提交范围

本分支相对 `main` 的关键非 merge 提交：

- `3f9d437` release: v0.38.1 stability fixes for streaming + telegram gateway
- `3f6d9b9` release: v0.38.2 provider resilience and config propagation
- `6a722c0` release: v0.38.3 gateway control + telegram runtime commands
- `623c84b` chore: commit remaining pending changes
- `0f01101` fix(agent): guard tool-call loops and align completion token field

## 4. 核心改动

### 4.1 消息网关跨进程控制

- `lh msg-gateway status/stop` 改为通过运行中 API 进程控制，不再依赖本地新建 `Agent` 的内存态。
- 新增 `--api-addr`（默认回落到 `msg_gateway.api_addr`，再到 `127.0.0.1:9090`）。
- 改进 API 错误解析与返回信息。

主要文件：

- `cmd/lh/main.go`
- `internal/server/server.go`

### 4.2 Telegram 命令运行时能力

- `/stop`：支持取消当前 chat 的正在执行任务。
- `/restart`：支持 Telegram adapter 的 stop/start 重连流程，增加防重入保护。
- 聊天处理改为异步分发，避免长任务阻塞 update 处理循环。
- 增加 per-chat 可取消任务跟踪与取消错误分支处理。

主要文件：

- `internal/gateway/telegram/handler.go`
- `internal/gateway/telegram/telegram_v054_test.go`

### 4.3 Agent loop 防死循环

- 增加重复工具调用检测（同名+同参数签名重复触发）。
- 增加连续“仅工具调用无文本产出”迭代检测。
- 触发保护后提前结束 loop，并返回最近工具输出摘要，避免空转到 max-iterations。
- 根据用户输入中显式点名工具，做工具暴露过滤（提高可控性）。

主要文件：

- `internal/agent/loop.go`
- `internal/agent/loop_test.go`
- `internal/agent/agent_integration_test.go`

### 4.4 Provider 与配置一致性改进

- OpenAI 请求体补充 `max_completion_tokens`（保持兼容）。
- Provider 传参补齐 `extra_headers`。
- Web search 环境变量策略调整为“配置文件优先，环境变量仅补空”。
- `config` 结构补齐 `agent/server/dashboard/msg_gateway` 字段与默认值；CLI 启动命令读取这些配置。
- `ConfigWatcher` 改为复用 JSON 配置解析路径，避免 YAML-only 假设。

主要文件：

- `internal/provider/openai_stream.go`
- `internal/agent/agent.go`
- `internal/config/config.go`
- `internal/config/watcher.go`
- `cmd/lh/main.go`
- `cmd/lh/chat_repl.go`
- `config.example.json`
- `docs/CONFIGURATION.md`

## 5. 行为变化与兼容性

- 无外部 API 破坏性变更。
- CLI 默认行为更依赖 `config.json`，但 CLI 显式参数仍优先。
- Telegram `/restart` 为网关级重连，不是进程级重启。

## 6. 测试与验证

本地执行（当前分支）：

```bash
go test ./internal/agent ./internal/provider ./internal/server ./internal/tool ./internal/config
```

结果：

- `internal/agent`: PASS
- `internal/provider`: PASS
- `internal/server`: PASS
- `internal/tool`: PASS
- `internal/config`: PASS

补充说明：

- 在受限沙箱中 `internal/server` 的 socket 测试可能失败（`operation not permitted`），在非沙箱环境已通过。

## 7. 风险评估

- 中风险点：Telegram 命令处理异步化引入并发路径，已通过现有回归测试覆盖基础流程。
- 中风险点：Agent loop 新增“提前终止”策略，可能在边缘场景提前收敛；当前阈值偏保守（重复 >=3 或连续工具轮次 >=3）。
- 低风险点：CLI 配置回落逻辑更完整，主要是增强，不影响显式参数。

## 8. 回滚方案

- 快速回滚：`git revert 0f01101 623c84b 6a722c0`（如需保留 v0.38.1/0.38.2，则不回滚 `3f9d437`/`3f6d9b9`）。
- 或直接回退到 `origin/main` 基线重新 cherry-pick 需要的提交。

## 9. Checklist

- [x] 关键功能修复（gateway / telegram / agent loop）
- [x] 测试补充（loop / server / skill loader / provider transport）
- [x] 配置示例与配置文档更新
- [x] 变更可回滚路径明确

