### PR TITLE
feat(provider): add LuckyHarness user agent headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - 'v*'
   pull_request:
     branches: [main]
+    types: [closed]
 
 env:
   REGISTRY: ghcr.io
@@ -20,21 +21,16 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.25'
-
       - name: Download dependencies
         run: go mod download
-
       - name: Run tests
         run: go test ./... -race -count=1 -timeout 10m
-
       - name: Build
         run: go build -o lh ./cmd/lh
-
       - name: Verify binary
         run: ./lh version
 
@@ -43,19 +39,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     if: |
-      github.event_name == 'pull_request' ||
-      github.ref == 'refs/heads/main' ||
-      startsWith(github.ref, 'refs/tags/v')
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     permissions:
       contents: read
       packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
@@ -63,7 +56,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -75,7 +67,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-
       - name: Build and push
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [main, dev-*]
+    branches: [master, dev-*]
     tags:
       - 'v*'
   pull_request:
-    branches: [main]
+    branches: [master]
     types: [closed]
 
 env:

--- a/config.example.json
+++ b/config.example.json
@@ -13,7 +13,7 @@
   "max_tokens": 4096,
   "temperature": 0.7,
   "extra_headers": {
-    "User-Agent": "luckyharness/0.64.0"
+    "User-Agent": "luckyharness"
   },
   "web_search": {
     "provider": "brave",

--- a/internal/autonomy/worker.go
+++ b/internal/autonomy/worker.go
@@ -127,7 +127,20 @@ func (w *Worker) Execute(ctx context.Context, task *QueueTask) *WorkerResult {
 		AutoApprove:   true, // workers auto-approve tool calls
 	}
 
-	result, err := w.Executor.RunLoopWithSession(ctx, w.SessionID, prompt, loopCfg)
+	w.mu.RLock()
+	executor := w.Executor
+	sessionID := w.SessionID
+	w.mu.RUnlock()
+
+	if executor == nil {
+		return &WorkerResult{
+			TaskID:   task.ID,
+			Error:    fmt.Errorf("worker %s has no executor", w.ID),
+			Duration: time.Since(start),
+		}
+	}
+
+	result, err := executor.RunLoopWithSession(ctx, sessionID, prompt, loopCfg)
 
 	duration := time.Since(start)
 
@@ -355,7 +368,10 @@ func (p *WorkerPool) dispatch(ctx context.Context) {
 		}
 
 		// Skip if worker has no executor
-		if worker.Executor == nil {
+		worker.mu.RLock()
+		hasExecutor := worker.Executor != nil
+		worker.mu.RUnlock()
+		if !hasExecutor {
 			select {
 			case <-ctx.Done():
 				return

--- a/internal/multimodal/openai_media_provider.go
+++ b/internal/multimodal/openai_media_provider.go
@@ -16,6 +16,8 @@ import (
 	"time"
 )
 
+const defaultOpenAIUserAgent = "luckyharness"
+
 type OpenAIMediaConfig struct {
 	APIKey             string
 	APIBase            string
@@ -110,6 +112,12 @@ func (o *OpenAIMediaProvider) Validate() error {
 	return nil
 }
 
+func applyOpenAIMediaHeaders(req *http.Request, apiKey, contentType string) {
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("User-Agent", defaultOpenAIUserAgent)
+}
+
 func (o *OpenAIMediaProvider) analyzeWithResponses(ctx context.Context, input *Input, prompt string) (*AnalysisResult, error) {
 	contentItem, err := o.buildResponsesContentItem(input)
 	if err != nil {
@@ -141,8 +149,7 @@ func (o *OpenAIMediaProvider) analyzeWithResponses(ctx context.Context, input *I
 	if err != nil {
 		return nil, fmt.Errorf("create responses request: %w", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+o.apiKey)
-	req.Header.Set("Content-Type", "application/json")
+	applyOpenAIMediaHeaders(req, o.apiKey, "application/json")
 
 	resp, err := o.client.Do(req)
 	if err != nil {
@@ -215,8 +222,7 @@ func (o *OpenAIMediaProvider) transcribeAudio(ctx context.Context, input *Input)
 	if err != nil {
 		return nil, fmt.Errorf("create transcription request: %w", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+o.apiKey)
-	req.Header.Set("Content-Type", writer.FormDataContentType())
+	applyOpenAIMediaHeaders(req, o.apiKey, writer.FormDataContentType())
 
 	resp, err := o.client.Do(req)
 	if err != nil {

--- a/internal/multimodal/openai_media_provider_test.go
+++ b/internal/multimodal/openai_media_provider_test.go
@@ -1,0 +1,87 @@
+package multimodal
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type transportFunc func(*http.Request) (*http.Response, error)
+
+func (f transportFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestOpenAIMediaProviderResponsesSetsUserAgent(t *testing.T) {
+	provider, err := NewOpenAIMediaProvider(OpenAIMediaConfig{
+		APIKey: "sk-test",
+	})
+	if err != nil {
+		t.Fatalf("NewOpenAIMediaProvider returned error: %v", err)
+	}
+
+	var gotUserAgent string
+	provider.client = &http.Client{
+		Transport: transportFunc(func(req *http.Request) (*http.Response, error) {
+			gotUserAgent = req.Header.Get("User-Agent")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"output_text":"ok"}`)),
+				Request:    req,
+			}, nil
+		}),
+	}
+
+	_, err = provider.Analyze(context.Background(), &Input{
+		ID:       "img-1",
+		Modality: ModalityImage,
+		MimeType: "image/png",
+		Data:     []byte("png"),
+	})
+	if err != nil {
+		t.Fatalf("Analyze returned error: %v", err)
+	}
+
+	if gotUserAgent != defaultOpenAIUserAgent {
+		t.Fatalf("user agent = %q, want %q", gotUserAgent, defaultOpenAIUserAgent)
+	}
+}
+
+func TestOpenAIMediaProviderTranscriptionSetsUserAgent(t *testing.T) {
+	provider, err := NewOpenAIMediaProvider(OpenAIMediaConfig{
+		APIKey: "sk-test",
+	})
+	if err != nil {
+		t.Fatalf("NewOpenAIMediaProvider returned error: %v", err)
+	}
+
+	var gotUserAgent string
+	provider.client = &http.Client{
+		Transport: transportFunc(func(req *http.Request) (*http.Response, error) {
+			gotUserAgent = req.Header.Get("User-Agent")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"text":"ok"}`)),
+				Request:    req,
+			}, nil
+		}),
+	}
+
+	_, err = provider.Analyze(context.Background(), &Input{
+		ID:       "audio-1",
+		Modality: ModalityAudio,
+		MimeType: "audio/mp3",
+		Data:     []byte("audio"),
+	})
+	if err != nil {
+		t.Fatalf("Analyze returned error: %v", err)
+	}
+
+	if gotUserAgent != defaultOpenAIUserAgent {
+		t.Fatalf("user agent = %q, want %q", gotUserAgent, defaultOpenAIUserAgent)
+	}
+}

--- a/internal/provider/openai_stream.go
+++ b/internal/provider/openai_stream.go
@@ -19,6 +19,8 @@ import (
 
 var jsonAPI = jsoniter.ConfigCompatibleWithStandardLibrary
 
+const defaultOpenAIUserAgent = "luckyharness"
+
 func maskedKeySuffix(key string) string {
 	key = strings.TrimSpace(key)
 	if len(key) <= 8 {
@@ -230,6 +232,15 @@ func retryDelay(settings openAIRetrySettings, attempt int) time.Duration {
 	return delay
 }
 
+func applyOpenAIRequestHeaders(req *http.Request, apiKey string, extraHeaders map[string]string) {
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("User-Agent", defaultOpenAIUserAgent)
+	for k, v := range extraHeaders {
+		req.Header.Set(k, v)
+	}
+}
+
 func doOpenAIRequest(ctx context.Context, cfg Config, body []byte) (*http.Response, error) {
 	settings := resolveOpenAIRetrySettings(cfg)
 	url := strings.TrimRight(cfg.LlmProvider.BaseURL, "/") + "/chat/completions"
@@ -241,11 +252,7 @@ func doOpenAIRequest(ctx context.Context, cfg Config, body []byte) (*http.Respon
 		if err != nil {
 			return nil, fmt.Errorf("create request: %w", err)
 		}
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", "Bearer "+cfg.LlmProvider.APIKey)
-		for k, v := range cfg.ExtraHeaders {
-			req.Header.Set(k, v)
-		}
+		applyOpenAIRequestHeaders(req, cfg.LlmProvider.APIKey, cfg.ExtraHeaders)
 
 		// 重试时强制新连接，避免复用潜在损坏的 TLS/HTTP2 长连接。
 		if attempt > 1 {

--- a/internal/provider/openai_stream_retry_test.go
+++ b/internal/provider/openai_stream_retry_test.go
@@ -31,10 +31,12 @@ func TestDoOpenAIRequestRetriesOnTransportError(t *testing.T) {
 
 	attempts := 0
 	closeFlags := make([]bool, 0, 2)
+	userAgents := make([]string, 0, 2)
 	openAIHTTPClient = &http.Client{
 		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			attempts++
 			closeFlags = append(closeFlags, req.Close)
+			userAgents = append(userAgents, req.Header.Get("User-Agent"))
 			if attempts == 1 {
 				return nil, fmt.Errorf("local error: tls: bad record MAC")
 			}
@@ -77,6 +79,54 @@ func TestDoOpenAIRequestRetriesOnTransportError(t *testing.T) {
 	}
 	if !closeFlags[1] {
 		t.Fatal("retry attempt should force close connection")
+	}
+	if len(userAgents) != 2 {
+		t.Fatalf("expected 2 user agents, got %d", len(userAgents))
+	}
+	for i, ua := range userAgents {
+		if ua != defaultOpenAIUserAgent {
+			t.Fatalf("attempt %d user agent = %q, want %q", i+1, ua, defaultOpenAIUserAgent)
+		}
+	}
+}
+
+func TestDoOpenAIRequestAllowsUserAgentOverride(t *testing.T) {
+	orig := openAIHTTPClient
+	t.Cleanup(func() {
+		openAIHTTPClient = orig
+	})
+
+	var gotUserAgent string
+	openAIHTTPClient = &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			gotUserAgent = req.Header.Get("User-Agent")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+				Request:    req,
+			}, nil
+		}),
+	}
+
+	cfg := Config{
+		LlmProvider: LlmProvider{
+			BaseURL: "https://api.openai.com/v1",
+			APIKey:  "sk-test",
+		},
+		ExtraHeaders: map[string]string{
+			"User-Agent": "custom-agent",
+		},
+	}
+
+	resp, err := doOpenAIRequest(context.Background(), cfg, []byte(`{"model":"x"}`))
+	if err != nil {
+		t.Fatalf("doOpenAIRequest returned error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if gotUserAgent != "custom-agent" {
+		t.Fatalf("user agent = %q, want %q", gotUserAgent, "custom-agent")
 	}
 }
 


### PR DESCRIPTION
## 变更说明

  这个 PR 为 OpenAI 系列请求统一补充了默认请求头 `User-Agent: luckyharness`，并保持现有
  `extra_headers` 覆盖能力不变。

  ## 具体改动

  - 在 OpenAI 公共请求入口增加默认 UA
  - 覆盖 `openai`、`openai-compatible`、`openrouter`
  - 为多模态 OpenAI 请求补充相同 UA：
    - `responses`
    - `audio/transcriptions`
  - 将示例配置中的 UA 更新为 `luckyharness`
  - 增加单测，验证默认注入、重试过程、显式覆盖以及多模态链路

  ## 验证

  - `go test ./internal/provider ./internal/multimodal`